### PR TITLE
Ghost CMS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,25 +14,20 @@ workflows:
     jobs:
       - docker/publish:
           image: pennlabs/labs-helm
-          tag: $CIRCLE_SHA1
-          context: docker-publish
-          path: docker/labs-helm
-          <<: *branch-filters
-      - docker/publish:
-          image: pennlabs/labs-helm
-          tag: latest
+          tag: "${CIRCLE_SHA1},latest"
           context: docker-publish
           path: docker/labs-helm
           <<: *branch-filters
       - docker/publish:
           image: pennlabs/team-sync
-          tag: $CIRCLE_SHA1
+          tag: "${CIRCLE_SHA1},latest"
           context: docker-publish
           path: docker/team-sync
           <<: *branch-filters
       - docker/publish:
-          image: pennlabs/team-sync
-          tag: latest
+          image: pennlabs/ghost-s3
+          tag: "${CIRCLE_SHA1},latest"
           context: docker-publish
-          path: docker/team-sync
+          path: docker/ghost-s3
           <<: *branch-filters
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  docker: circleci/docker@0.5.13
+  docker: circleci/docker@0.5.19
 
 branch-filters: &branch-filters
   filters:

--- a/BOOTSTRAPPING.md
+++ b/BOOTSTRAPPING.md
@@ -178,4 +178,4 @@ Create a secret in `secrets/data/bitwarden` with two attributes:
 ### Configure Ghost
 
 See the [Ghost README](https://github.com/pennlabs/infrastructure/tree/master/ghost) for descriptions of
-secrets that need to be set in `secrests/data/ghost`.
+secrets that need to be set in `secrets/data/ghost`.

--- a/BOOTSTRAPPING.md
+++ b/BOOTSTRAPPING.md
@@ -174,3 +174,8 @@ Create a secret in `secrets/data/bitwarden` with two attributes:
 
 - `ADMIN_TOKEN` - A (long) secure token to access the bitwarden admin page.
 - `DATABASE_URL` - The database url of the mysql database to use.
+
+### Configure Ghost
+
+See the [Ghost README](https://github.com/pennlabs/infrastructure/tree/master/ghost) for descriptions of
+secrets that need to be set in `secrests/data/ghost`.

--- a/docker/ghost-s3/Dockerfile
+++ b/docker/ghost-s3/Dockerfile
@@ -2,10 +2,7 @@ FROM ghost:3.1
 
 # inspired by: https://github.com/macchie/docker-ghost-scs/blob/master/Dockerfile
 # https://github.com/colinmeinke/ghost-storage-adapter-s3
-RUN mkdir -p ./content.orig/adapters/storage
+RUN mkdir -p content.orig/adapters/storage
 RUN npm install ghost-s3-storage-adapter && \
-    cp -r ./node_modules/ghost-s3-storage-adapter \
-    ./content.orig/adapters/storage/s3
-
-ENV storage__active s3
-
+    cp -r node_modules/ghost-s3-storage-adapter \
+    content.orig/adapters/storage/s3

--- a/docker/ghost-s3/Dockerfile
+++ b/docker/ghost-s3/Dockerfile
@@ -1,7 +1,8 @@
 FROM ghost:3.1 
 
+# inspired by: https://github.com/macchie/docker-ghost-scs/blob/master/Dockerfile
+# https://github.com/colinmeinke/ghost-storage-adapter-s3
 RUN mkdir -p ./content.orig/adapters/storage
-
 RUN npm install ghost-s3-storage-adapter && \
     cp -r ./node_modules/ghost-s3-storage-adapter \
     ./content.orig/adapters/storage/s3

--- a/docker/ghost-s3/Dockerfile
+++ b/docker/ghost-s3/Dockerfile
@@ -1,0 +1,10 @@
+FROM ghost:3.1 
+
+RUN mkdir -p ./content.orig/adapters/storage
+
+RUN npm install ghost-s3-storage-adapter && \
+    cp -r ./node_modules/ghost-s3-storage-adapter \
+    ./content.orig/adapters/storage/s3
+
+ENV storage__active s3
+

--- a/ghost/README.md
+++ b/ghost/README.md
@@ -7,18 +7,18 @@ nested fields are accessed with a `__` (double underscore), just like in the Dja
 
 Here are the secrets that need to be set:
 
-|             Key                       |  Description                                                |
-|---------------------------------------|-------------------------------------------------------------|
-| AWS_ACCESS_KEY_ID                     |                                                             |
-| AWS_DEFAULT_REGION                    |                                                             |
-| AWS_SECRET_ACCESS_KEY                 |                                                             |
-| GHOST_STORAGE_ADAPTER_S3_PATH_BUCKET  |                                                             |
-| database__connection__database        | The name of the MySQL database to be used to store content. |
-| database__connection__host            | Hostname for the MySQL database.                            |
-| database__connection__user            | Database user for ghost to log in as.                       |
-| database__connection__password        | Password for the MySQL database user.                       |
-| mail__options__auth__user             | SMTP user                                                   |
-| mail__options__auth__pass             | SMTP password                                               |
+|               Key                       |  Description                                                |
+|------ ----------------------------------|-------------------------------------------------------------|
+| `AWS_ACCESS_KEY_ID`                     |                                                             |
+| `AWS_DEFAULT_REGION`                    |                                                             |
+| `AWS_SECRET_ACCESS_KEY`                 |                                                             |
+| `GHOST_STORAGE_ADAPTER_S3_PATH_BUCKET`  |                                                             |
+| `database__connection__database`        | The name of the MySQL database to be used to store content. |
+| `database__connection__host`            | Hostname for the MySQL database.                            |
+| `database__connection__user`            | Database user for ghost to log in as.                       |
+| `database__connection__password`        | Password for the MySQL database user.                       |
+| `mail__options__auth__user`             | SMTP user                                                   |
+| `mail__options__auth__pass`             | SMTP password                                               |
 
 Other configuration can also be set as `extraEnv` in values.yaml. 
 Right now, this includes things like the default ports for MySQL and SMTP.

--- a/ghost/README.md
+++ b/ghost/README.md
@@ -8,7 +8,7 @@ nested fields are accessed with a `__` (double underscore), just like in the Dja
 Here are the secrets that need to be set:
 
 |               Key                       |  Description                                                |
-|------ ----------------------------------|-------------------------------------------------------------|
+|-----------------------------------------|-------------------------------------------------------------|
 | `AWS_ACCESS_KEY_ID`                     |                                                             |
 | `AWS_DEFAULT_REGION`                    |                                                             |
 | `AWS_SECRET_ACCESS_KEY`                 |                                                             |

--- a/ghost/README.md
+++ b/ghost/README.md
@@ -1,9 +1,9 @@
 # Ghost
 
-Ghost is a Content Management System (CMS) for blogging. Think of it like the backend of a blog, but it's built so that it can be very easily accessed via an API. An example for NextJS is [here](https://ghost.org/docs/api/v3/nextjs/)
+Ghost is a Content Management System (CMS) for blogging. Think of it like the backend of a blog, but it's built so that it can be very easily accessed via an API. An example for NextJS is [here](https://ghost.org/docs/api/v3/nextjs/).
 
 Normally ghost is configured using a JSON file. But we can also set all the configuration through environment variables, where
-nested fields are accessed with a `__` (double underscore), just like in the Django ORM.
+nested fields are accessed with a double underscore, just like in the Django ORM.
 
 Here are the secrets that need to be set:
 

--- a/ghost/README.md
+++ b/ghost/README.md
@@ -1,0 +1,25 @@
+# Ghost
+
+Ghost is a Content Management System (CMS) for blogging. Think of it like the backend of a blog, but it's built so that it can be very easily accessed via an API. An example for NextJS is [here](https://ghost.org/docs/api/v3/nextjs/)
+
+Normally ghost is configured using a JSON file. But we can also set all the configuration through environment variables, where
+nested fields are accessed with a `__` (double underscore), just like in the Django ORM.
+
+Here are the secrets that need to be set:
+
+|             Key                       |  Description                                                |
+|---------------------------------------|-------------------------------------------------------------|
+| AWS_ACCESS_KEY_ID                     |                                                             |
+| AWS_DEFAULT_REGION                    |                                                             |
+| AWS_SECRET_ACCESS_KEY                 |                                                             |
+| GHOST_STORAGE_ADAPTER_S3_PATH_BUCKET  |                                                             |
+| database__connection__database        | The name of the MySQL database to be used to store content. |
+| database__connection__host            | Hostname for the MySQL database.                            |
+| database__connection__user            | Database user for ghost to log in as.                       |
+| database__connection__password        | Password for the MySQL database user.                       |
+| mail__options__auth__user             | SMTP user                                                   |
+| mail__options__auth__pass             | SMTP password                                               |
+
+Other configuration can also be set as `extraEnv` in values.yaml. 
+Right now, this includes things like the default ports for MySQL and SMTP.
+See the [official documentation](https://ghost.org/docs/concepts/config/) for all configuration options.

--- a/ghost/chart/Chart.yaml
+++ b/ghost/chart/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: template
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/ghost/chart/templates/deployment.yaml
+++ b/ghost/chart/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Release.Name }}-dep
+  namespace: {{ .Release.namespace }}
   labels:
     name: {{ .Release.Name }}
 spec:
@@ -20,11 +21,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - containerPort: {{ .Values.service.port }}
-          env:
-            - name: ENABLE_DB_WAL
-              value: "false"
-            - name: SIGNUPS_ALLOWED
-              value: "false"
           envFrom:
             - secretRef:
                 name: {{ .Values.secrets.secretEnv }}
+          env:
+            {{- if .Values.extraEnv }}
+            {{ toYaml .Values.extraEnv | indent 12 }}
+            {{- end }}
+

--- a/ghost/chart/templates/ingress.yaml
+++ b/ghost/chart/templates/ingress.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.ingress.enabled -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ .Release.Name }}-svc
+              servicePort: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/ghost/chart/templates/service.yaml
+++ b/ghost/chart/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-svc
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector:
+    name: {{ .Release.Name }}

--- a/ghost/chart/values.yaml
+++ b/ghost/chart/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+image:
+  repository: nginx
+  pullPolicy: IfNotPresent
+  tag: latest
+
+extraEnv: []
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths: ["/"]

--- a/ghost/init.sh
+++ b/ghost/init.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+helm upgrade --install --atomic ghost -f values.yml chart/

--- a/ghost/init.sh
+++ b/ghost/init.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-helm upgrade --install --atomic ghost -f values.yml chart/
+helm upgrade --install --atomic ghost -f values.yaml chart/

--- a/ghost/values.yaml
+++ b/ghost/values.yaml
@@ -1,0 +1,29 @@
+image:
+  repository: pennlabs/ghost
+  tag: latest
+
+service:
+  type: ClusterIP
+
+ingress:
+  enabled: true
+  hosts:
+    - host: blog.pennlabs.org
+      paths: ["/"]
+
+extraEnv:
+  - name: url
+    value: https://blog.pennlabs.org
+  - name: database__client
+    value: mysql
+  - name: database__ssl
+    value: true
+  - name: mail__transport
+    value: SMTP
+  - name: mail__from
+    value: blogmaster@pennlabs.org
+  - name: mail__options__service
+    value: Mailgun
+  
+
+secretEnv: ghost

--- a/ghost/values.yaml
+++ b/ghost/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: pennlabs/ghost
+  repository: pennlabs/ghost-s3
   tag: latest
 
 service:

--- a/ghost/values.yaml
+++ b/ghost/values.yaml
@@ -27,4 +27,5 @@ extraEnv:
     value: Mailgun
   
 
-secretEnv: ghost
+secrets:
+  secretEnv: ghost

--- a/ghost/values.yaml
+++ b/ghost/values.yaml
@@ -25,6 +25,8 @@ extraEnv:
     value: "'Penn Labs' <blogmaster@pennlabs.org>"
   - name: mail__options__service
     value: Mailgun
+  - name: storage__active
+    value: s3
   
 
 secrets:

--- a/ghost/values.yaml
+++ b/ghost/values.yaml
@@ -4,6 +4,7 @@ image:
 
 service:
   type: ClusterIP
+  port: 2368
 
 ingress:
   enabled: true
@@ -21,7 +22,7 @@ extraEnv:
   - name: mail__transport
     value: SMTP
   - name: mail__from
-    value: blogmaster@pennlabs.org
+    value: "'Penn Labs' <blogmaster@pennlabs.org>"
   - name: mail__options__service
     value: Mailgun
   

--- a/init_cluster.sh
+++ b/init_cluster.sh
@@ -28,7 +28,7 @@ export KUBECONFIG=$PWD/kubeconfig.yaml
 
 kubectl create ns staging
 
-for dir in etcd traefik vault monitoring bitwarden; do
+for dir in etcd traefik vault monitoring bitwarden ghost; do
   cd $dir
   ./init.sh
   cd ..


### PR DESCRIPTION
This PR adds a helm chart + dockerfile for [Ghost](https://ghost.org/docs/concepts/introduction/), a headless content management system to manage the Penn Labs blog.

Only thing left to do is to add an s3 bucket to terraform that holds all the uploaded image assets, so we're not saving them to a PVC or a local filesystem. Some details here: https://github.com/colinmeinke/ghost-storage-adapter-s3

[ch328]