### PR TITLE
Add DO mysql firewall

### DIFF
--- a/tf/main.tf
+++ b/tf/main.tf
@@ -19,6 +19,15 @@ resource "digitalocean_database_cluster" "mysql-infra" {
   node_count = 1
 }
 
+resource "digitalocean_database_firewall" "mysql-fw" {
+  cluster_id = digitalocean_database_cluster.mysql-infra.id
+
+  rule {
+    type  = "k8s"
+    value = digitalocean_kubernetes_cluster.labs-prod.id
+  }
+}
+
 resource "digitalocean_database_db" "vault" {
   cluster_id = digitalocean_database_cluster.mysql-infra.id
   name       = "vault"


### PR DESCRIPTION
This PR adds a firewall rule to the DO MySQL cluster that only allows access from the k8s cluster. This PR is untested and should be checked before merging.

Documentation for the resource being used is [here](https://www.terraform.io/docs/providers/do/r/database_firewall.html)