### PR TITLE
Database backup cronjobs

### DIFF
--- a/terraform/base/db-backup.tf
+++ b/terraform/base/db-backup.tf
@@ -1,0 +1,10 @@
+resource "helm_release" "db-backup" {
+  name       = "db-backup"
+  repository = "https://helm.pennlabs.org"
+  chart      = "icarus"
+  version    = "0.1.20"
+
+  values = [
+    "${file("helm-production/db-backup.yaml")}"
+  ]
+}

--- a/terraform/base/helm-production/db-backup.yaml
+++ b/terraform/base/helm-production/db-backup.yaml
@@ -1,0 +1,17 @@
+cronjobs:
+  - name: backup-infrastructure
+    schedule: "21 2 * * *"
+    secret: backup-infrastructure
+    image: pennlabs/pg-s3-backup
+    tag: e0c46acfaacb1a135d0eab57cc9044197aa2c890
+    extraEnv:
+      - name: AWS_DEFAULT_REGION
+        value: "us-east-1"
+  - name: backup-production
+    schedule: "21 2 * * *"
+    secret: backup-production
+    image: pennlabs/pg-s3-backup
+    tag: e0c46acfaacb1a135d0eab57cc9044197aa2c890
+    extraEnv:
+      - name: AWS_DEFAULT_REGION
+        value: "us-east-1"


### PR DESCRIPTION
This PR creates two cronjobs to backup our production and infrastructure databases to AWS daily. Note that I'm intentionally not including the creation of the IAM user or vault secrets in the PR as these will be handled later in our planned S3 terraform module