### PR TITLE
Modify backup names

### DIFF
--- a/.github/workflows/pg-s3-backup.yaml
+++ b/.github/workflows/pg-s3-backup.yaml
@@ -1,8 +1,6 @@
 name: Publish pg-s3-backup
 on:
   push:
-    branches:
-      - master
     paths:
       - "docker/pg-s3-backup/**"
 jobs:
@@ -17,4 +15,5 @@ jobs:
           path: docker/pg-s3-backup
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+          push: ${{ github.ref == 'refs/heads/master' }}
           tags: "latest,${{ github.sha }}"

--- a/docker/pg-s3-backup/backup
+++ b/docker/pg-s3-backup/backup
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Get current timestamp
-STAMP=`date +"%s - %A %d %B %Y @ %H:%M"`
+STAMP=`date +"%Y%m%d - %A %d %B %Y @ %H:%M"`
 
 # List all databases and remove default databases
 DATABASES=`psql $DATABASE_URL/defaultdb -q -t -c 'SELECT datname from pg_database' | grep -v "\(_dodb\|template1\|template0\|defaultdb\)"`


### PR DESCRIPTION
This PR modifies the backup docker image to ensure that the backups for both the production and infrastructure databases end up in the same folder. Previously they would differ by ~1 second when starting which would result in different folders being created.