### PR TITLE
Add Atlantis

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -1,0 +1,14 @@
+version: 3
+projects:
+  - name: chronos
+    dir: terraform/chronos
+    autoplan:
+      when_modified: ["*.tf", "../modules/**.tf"]
+  - name: base
+    dir: terraform/base
+    autoplan:
+      when_modified: ["*.tf", "../modules/**.tf"]
+  - name: vault
+    dir: terraform/vault
+    autoplan:
+      when_modified: ["*.tf"]

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -81,7 +81,7 @@ Now export the following environment variables
 | TF_VAR_GF_GH_CLIENT_SECRET | The Client Secret to the Grafana Penn Labs OAuth2 application on Github                                                                                                           |
 | TF_VAR_GF_SLACK_URL        | Slack notification URL used for Grafana notifications                                                                                                                             |
 | TF_VAR_ELASTIC_PASSWORD    | The password to the managed elasticsearch instance                                                                                                                                |
-| TF_VAR_ELASTIC_HOST        | The host to the managed elasticsearch instance (format should be https://host:port)                                                                                               |
+| TF_VAR_ELASTIC_HOST        | The host to the managed elasticsearch instance (format should be <https://host:port>)                                                                                             |
 | VAULT_ADDR                 | Set this to <https://vault.upenn.club>                                                                                                                                            |
 
 Run the following commands:
@@ -91,6 +91,14 @@ cd ../vault
 terraform init
 terraform apply
 ```
+
+Now create a secret in vault at the path `secrets/production/default/atlantis` with the all the previous environment variables set (AWS, DigitalOcean, Vault, and TF_VAR_*) as well as the following values:
+| Name                       | Description                                             |
+|----------------------------|---------------------------------------------------------|
+| ATLANTIS_GH_APP_ID         | The ID of the Penn Labs Atlantis GitHub App             |
+| ATLANTIS_GH_APP_KEY        | The private key of the Penn Labs Atlantis GitHub App    |
+| ATLANTIS_GH_WEBHOOK_SECRET | The webhook secret of the Penn Labs Atlantis GitHub App |
+| VAULT_ADDR                 | <https://vault.pennlabs.org>                            |
 
 The last step is to deploy the sandbox and production clusters. First, log into vault and create empty secrets for all of our products (named `locals.database_users` in `base/main.tf`) with the path `secrets/production/default/<product name>`. Then run the following commands
 

--- a/terraform/base/README.md
+++ b/terraform/base/README.md
@@ -23,6 +23,10 @@ Configures terraform to use the `base` remote S3 backend as well as the followin
 
 Also configures [terraform remote state](https://www.terraform.io/docs/providers/terraform/d/remote_state.html) for `chronos` and `vault` to gain access to credentials generated from those terraform projects.
 
+## atlantis.tf
+
+Installs [atlantis](https://www.runatlantis.io/) through [this helm chart](https://github.com/helm/charts/tree/master/stable/atlantis) on to our production cluster.
+
 ## bitwarden.tf
 
 Installs [bitwarden_rs](https://github.com/dani-garcia/bitwarden_rs) through [Icarus](https://github.com/pennlabs/icarus) on to our production cluster.

--- a/terraform/base/atlantis.tf
+++ b/terraform/base/atlantis.tf
@@ -1,0 +1,10 @@
+resource "helm_release" "atlantis" {
+  name       = "atlantis"
+  repository = "https://kubernetes-charts.storage.googleapis.com"
+  chart      = "atlantis"
+  version    = "3.12.0"
+
+  values = [
+    "${file("helm-production/atlantis.yaml")}"
+  ]
+}

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -2,11 +2,12 @@ orgWhitelist: github.com/pennlabs/infrastructure
 
 # Atlantis requires the GitHub app private key to be saved in a file
 # This workaround allows us to load it from an environment variable from vault
+# Additional flags are also specified here until the helm chart includes them natively
 command:
   [
     "/bin/sh",
     "-c",
-    'echo "$ATLANTIS_GH_APP_KEY" > /home/atlantis/gh_app_key.pem && atlantis server --hide-prev-plan-comments --write-git-creds --gh-app-key-file=/home/atlantis/gh_app_key.pem',
+    'echo "$ATLANTIS_GH_APP_KEY" > /home/atlantis/gh_app_key.pem && atlantis server --silence-vcs-status-no-plans --hide-prev-plan-comments --write-git-creds --gh-app-key-file=/home/atlantis/gh_app_key.pem',
   ]
 
 image:

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -6,7 +6,7 @@ command:
   [
     "/bin/sh",
     "-c",
-    'echo "$ATLANTIS_GH_APP_KEY" > /home/atlantis/gh_app_key.pem && atlantis server --write-git-creds --gh-app-key-file=/home/atlantis/gh_app_key.pem',
+    'echo "$ATLANTIS_GH_APP_KEY" > /home/atlantis/gh_app_key.pem && atlantis server --hide-prev-plan-comments --write-git-creds --gh-app-key-file=/home/atlantis/gh_app_key.pem',
   ]
 
 image:

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -1,0 +1,52 @@
+orgWhitelist: pennlabs
+
+# Atlantis requires the GitHub app private key to be saved in a file
+# This workaround allows us to load it from an environment variable from vault
+command:
+  [
+    "/bin/sh",
+    "-c",
+    'echo "$ATLANTIS_GH_APP_KEY" > /home/atlantis/gh_app_key.pem && atlantis server --write-git-creds --gh-app-key-file=/home/atlantis/gh_app_key.pem',
+  ]
+
+image:
+  repository: runatlantis/atlantis
+  tag: v0.14.0
+  pullPolicy: IfNotPresent
+
+## Use Server Side Repo Config,
+## ref: https://www.runatlantis.io/docs/server-side-repo-config.html
+repoConfig: |
+  ---
+  repos:
+  - id: github.com/pennlabs/infrastructure
+    apply_requirements: [approved, mergeable]
+    workflow: default
+    allowed_overrides: []
+    allow_custom_workflows: false
+  workflows:
+    default:
+      plan:
+        steps: [init, plan]
+      apply:
+        steps: [apply]
+
+defaultTFVersion: 0.12.27
+
+ingress:
+  enabled: true
+  path: /
+  host: atlantis-sandbox.pennlabs.org
+  tls:
+    - secretName: pennlabs-org-tls
+      hosts:
+        - atlantis-sandbox.pennlabs.org
+
+## test container details
+test:
+  enabled: true
+  image: lachlanevenson/k8s-kubectl
+  imageTag: v1.4.8-bash
+
+loadEnvFromSecrets:
+  - atlantis

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -19,11 +19,11 @@ image:
 repoConfig: |
   ---
   repos:
-  - id: github.com/pennlabs/infrastructure
-    apply_requirements: [approved, mergeable]
-    workflow: default
-    allowed_overrides: []
-    allow_custom_workflows: false
+    - id: github.com/pennlabs/infrastructure
+      apply_requirements: [approved, mergeable]
+      workflow: default
+      allowed_overrides: []
+      allow_custom_workflows: false
   workflows:
     default:
       plan:

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -1,4 +1,4 @@
-orgWhitelist: pennlabs
+orgWhitelist: github.com/pennlabs/infrastructure
 
 # Atlantis requires the GitHub app private key to be saved in a file
 # This workaround allows us to load it from an environment variable from vault


### PR DESCRIPTION
This PR configures Atlantis to manage our terraform configs. Right now, a shadow version of Atlantis is running on `sandbox` which will be used to merge this PR and apply the new terraform configs.

We need to wait until a PR I made in the Atlantis helm chart is merged before we can merge this PR.

After merging this PR, the Atlantis GitHub app needs to be updated to change all references from atlantis-sandbox.pennlabs.org to atlantis.pennlabs.org