### PR TITLE
Refresh Chronos on Base Changes

### DIFF
--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -12,7 +12,15 @@ projects:
         - helm-sandbox/*.yaml"
         - helm-production/*.yaml"
         - "../modules/**/*.tf"
+    workflow: base
   - name: vault
     dir: terraform/vault
     autoplan:
       when_modified: ["*.tf", "policies/*.hcl"]
+
+workflows:
+  base:
+    plan:
+      steps:
+        - run: terraform refresh ../chronos
+        - plan

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -17,10 +17,3 @@ projects:
     dir: terraform/vault
     autoplan:
       when_modified: ["*.tf", "policies/*.hcl"]
-
-workflows:
-  base:
-    plan:
-      steps:
-        - run: terraform refresh ../chronos
-        - plan

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -36,6 +36,7 @@ repoConfig: |
         steps:
           - run: cd ../chronos && /atlantis-data/bin/terraform${ATLANTIS_TERRAFORM_VERSION} init -input=false -no-color -upgrade
           - run: cd ../chronos && /atlantis-data/bin/terraform${ATLANTIS_TERRAFORM_VERSION} refresh -no-color
+          - run: echo "[SPLIT] BASE CHANGES UNDER HERE"
           - init
           - plan
 

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -23,7 +23,7 @@ repoConfig: |
     - id: github.com/pennlabs/infrastructure
       apply_requirements: [approved, mergeable]
       workflow: default
-      allowed_overrides: []
+      allowed_overrides: [workflow]
       allow_custom_workflows: false
   workflows:
     default:

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -24,13 +24,20 @@ repoConfig: |
       apply_requirements: [approved, mergeable]
       workflow: default
       allowed_overrides: []
-      allow_custom_workflows: true
+      allow_custom_workflows: false
   workflows:
     default:
       plan:
         steps: [init, plan]
       apply:
         steps: [apply]
+    base:
+      plan:
+        steps:
+          - run: terraform init ../chronos
+          - run: terraform refresh ../chronos
+          - init
+          - plan
 
 defaultTFVersion: 0.12.29
 

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -34,8 +34,10 @@ repoConfig: |
     base:
       plan:
         steps:
-          - run: terraform${ATLANTIS_TERRAFORM_VERSION} init -input=false -no-color -upgrade ../chronos
-          - run: terraform${ATLANTIS_TERRAFORM_VERSION} refresh ../chronos
+          - run: cd ../chronos
+          - run: /atlantis-data/bin/terraform${ATLANTIS_TERRAFORM_VERSION} init -input=false -no-color -upgrade
+          - run: /atlantis-data/bin/terraform${ATLANTIS_TERRAFORM_VERSION} refresh -no-color
+          - run: cd ../base
           - init
           - plan
 

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -34,8 +34,8 @@ repoConfig: |
     base:
       plan:
         steps:
-          - run: terraform init ../chronos
-          - run: terraform refresh ../chronos
+          - run: terraform${ATLANTIS_TERRAFORM_VERSION} init -input=false -no-color -upgrade ../chronos
+          - run: terraform${ATLANTIS_TERRAFORM_VERSION} refresh ../chronos
           - init
           - plan
 

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -34,10 +34,8 @@ repoConfig: |
     base:
       plan:
         steps:
-          - run: cd ../chronos
-          - run: /atlantis-data/bin/terraform${ATLANTIS_TERRAFORM_VERSION} init -input=false -no-color -upgrade
-          - run: /atlantis-data/bin/terraform${ATLANTIS_TERRAFORM_VERSION} refresh -no-color
-          - run: cd ../base
+          - run: cd ../chronos && /atlantis-data/bin/terraform${ATLANTIS_TERRAFORM_VERSION} init -input=false -no-color -upgrade
+          - run: cd ../chronos && /atlantis-data/bin/terraform${ATLANTIS_TERRAFORM_VERSION} refresh -no-color
           - init
           - plan
 

--- a/terraform/base/helm-production/atlantis.yaml
+++ b/terraform/base/helm-production/atlantis.yaml
@@ -24,7 +24,7 @@ repoConfig: |
       apply_requirements: [approved, mergeable]
       workflow: default
       allowed_overrides: []
-      allow_custom_workflows: false
+      allow_custom_workflows: true
   workflows:
     default:
       plan:

--- a/terraform/base/provider.tf
+++ b/terraform/base/provider.tf
@@ -9,7 +9,7 @@ provider "aws" {
 
 // Production K8s cluster
 provider "helm" {
-  version = "~> 1.0"
+  version = "~> 1.3"
   kubernetes {
     load_config_file = false
     host             = module.production-cluster.endpoint
@@ -33,7 +33,7 @@ provider "kubernetes" {
 // Sandbox K8s cluster
 provider "helm" {
   alias   = "sandbox"
-  version = "~> 1.0"
+  version = "~> 1.3"
   kubernetes {
     load_config_file = false
     host             = module.sandbox-cluster.endpoint
@@ -58,7 +58,7 @@ provider "kubernetes" {
 // Chronos K8s cluster
 provider "helm" {
   alias   = "chronos"
-  version = "~> 1.0"
+  version = "~> 1.3"
   kubernetes {
     load_config_file = false
     host             = data.terraform_remote_state.chronos.outputs.endpoint

--- a/terraform/chronos/provider.tf
+++ b/terraform/chronos/provider.tf
@@ -9,7 +9,7 @@ provider "aws" {
 
 // Chronos K8s cluster
 provider "helm" {
-  version = "~> 1.0"
+  version = "~> 1.3"
   kubernetes {
     load_config_file = false
     host             = module.chronos-cluster.endpoint


### PR DESCRIPTION
The PR ensures that a `terraform refresh` is run on chronos any time that changes to base are needed.

This is needed because without this explicit refresh, the kubeconfig stored in chronos would be invalidated after approximately 1 week and running terraform commands for base wouldn't refresh the config.