### PR TITLE
Manage GitHub org secrets in terraform

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -39,6 +39,24 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/github" {
+  version = "4.5.2"
+  hashes = [
+    "h1:7H2CZZoOFRe7BEZukBPjasgNlb4TNWrneUrRVCDFjR4=",
+    "zh:0bd14b4ab08970fd95a6e6f9de0ea128949e31d03dbf9b24b8a585d000f9d186",
+    "zh:22970d45ff5abc671574133397cca711b18b2fecf71fdb72ac37f4e16cb1ef59",
+    "zh:3f976037e257fe153b592bf0e95c182ad8bee859c5ad364c017855b67c977e83",
+    "zh:8468ef880152de2d576a2a436842ab30fce5edd16b9eb11be9768ffd4e22c8ee",
+    "zh:a752d1625449c2f769372e0f4291f9c81aa132880379186ed7ec18a851f46093",
+    "zh:ac74cbc20bf1f80228b25c0a37e0729f8e7f0b79f6aa9ee98eda595724bfaa5d",
+    "zh:b643023d50b2d261d11beb86e61d5bf7e579b517ec6b8a8abfe26e2a8a8481f4",
+    "zh:c098ac282a8bff702456a080a26d088002e36726ff961cb3f3d87aa5db874098",
+    "zh:c45027c4aa80f5ae14a6b81afbae0f10f161d9417eaa1da157caa7eb7db22d9f",
+    "zh:d905cb43ea3f3eadff73a4ccaf88933fc32513813230bfed8d6f5b039d74a9fe",
+    "zh:de4d157a176681fba735c5fb060278c9a986be5827908c5089c14cbd54e29b74",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/helm" {
   version     = "1.3.2"
   constraints = "~> 1.3"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -36,6 +36,10 @@ Finally, a populated kubeconfig is pushed to vault for platform members to use. 
 
 Creates an IAM user for GitHub Actions that can assume the `kubectl` IAM role as well as describe the EKS cluster (so that it can generate its own kubeconfig).
 
+## github.tf
+
+Creates organization GitHub Actions secrets used by our CI. Currently just AWS credentials and our AWS account ID.
+
 ## iam.tf
 
 Uses our [IAM Module](./modules/iam) to create IAM roles for all of our products that can be assumed by the correct Service Account in the `default` namespace.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,7 +16,7 @@ We use [Terraform](https://www.terraform.io/docs/index.html) to manage our infra
 
 Contains configuration to create a terraform S3 backend. `provider.tf` in is configured to use the remote S3 backend.
 
-## bastion
+## bastion.tf
 
 Configures a bastion that allows Team Leads to exec into pods (normally to run manage.py commands).
 

--- a/terraform/github.tf
+++ b/terraform/github.tf
@@ -1,0 +1,17 @@
+resource "github_actions_organization_secret" "aws_account_id" {
+  secret_name     = "AWS_ACCOUNT_ID"
+  visibility      = "all"
+  plaintext_value = data.aws_caller_identity.current.account_id
+}
+
+resource "github_actions_organization_secret" "aws_access_key" {
+  secret_name     = "GH_AWS_ACCESS_KEY_ID"
+  visibility      = "all"
+  plaintext_value = aws_iam_access_key.gh-actions.id
+}
+
+resource "github_actions_organization_secret" "aws_secret_key" {
+  secret_name     = "GH_AWS_SECRET_ACCESS_KEY"
+  visibility      = "all"
+  plaintext_value = aws_iam_access_key.gh-actions.secret
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,6 +43,8 @@ locals {
   traefik_lb_name = "a3b77cc4561e649d4bcc2a89e1b63d7d"
 }
 
+data "aws_caller_identity" "current" {}
+
 data "aws_iam_policy_document" "assume-kubectl" {
   statement {
     actions   = ["sts:AssumeRole"]

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -28,6 +28,10 @@ provider "postgresql" {
   sslmode          = "require"
 }
 
+provider "github" {
+  organization = "pennlabs"
+}
+
 terraform {
   backend "s3" {
     region         = "us-east-1"


### PR DESCRIPTION
A new release of the GitHub provider added the ability to manage organization GitHub Actions secrets. This PR configures terraform to create the secrets we need to deploy our products.