### PR TITLE
[Kraken] Pin OS version in django check tests

### DIFF
--- a/cdk/kraken/src/django.ts
+++ b/cdk/kraken/src/django.ts
@@ -15,7 +15,7 @@ export interface DjangoCheckJobProps {
 
   /**
    * Python version to test the project with.
-   * @default "3.8"
+   * @default "3.8-buster"
    */
   pythonVersion?: string;
 
@@ -59,7 +59,7 @@ export class DjangoCheckJob extends CheckoutJob {
     // Build config
     const fullConfig: Required<DjangoCheckJobProps> = {
       id: '',
-      pythonVersion: '3.8',
+      pythonVersion: '3.8-buster',
       path: '.',
       black: true,
       flake8: true,

--- a/cdk/kraken/test/__snapshots__/custom.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/custom.test.ts.snap
@@ -60,7 +60,7 @@ exit 1",
     },
     "django-check-one": Object {
       "container": Object {
-        "image": "python:3.8",
+        "image": "python:3.8-buster",
       },
       "env": Object {
         "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -122,7 +122,7 @@ pipenv run codecov --root $ROOT --flags backend",
     },
     "django-check-two": Object {
       "container": Object {
-        "image": "python:3.8",
+        "image": "python:3.8-buster",
       },
       "env": Object {
         "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",

--- a/cdk/kraken/test/__snapshots__/django-project.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/django-project.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "jobs": Object {
     "django-check-custom": Object {
       "container": Object {
-        "image": "python:3.8",
+        "image": "python:3.8-buster",
       },
       "env": Object {
         "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -119,7 +119,7 @@ Object {
   "jobs": Object {
     "django-check": Object {
       "container": Object {
-        "image": "python:3.8",
+        "image": "python:3.8-buster",
       },
       "env": Object {
         "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",

--- a/cdk/kraken/test/__snapshots__/django.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/django.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`default 1`] = `
 Object {
   "container": Object {
-    "image": "python:3.8",
+    "image": "python:3.8-buster",
   },
   "env": Object {
     "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -68,7 +68,7 @@ pipenv run codecov --root $ROOT --flags backend",
 exports[`different directory 1`] = `
 Object {
   "container": Object {
-    "image": "python:3.8",
+    "image": "python:3.8-buster",
   },
   "env": Object {
     "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -198,7 +198,7 @@ pipenv run codecov --root $ROOT --flags backend",
 exports[`no lint 1`] = `
 Object {
   "container": Object {
-    "image": "python:3.8",
+    "image": "python:3.8-buster",
   },
   "env": Object {
     "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -253,7 +253,7 @@ pipenv run codecov --root $ROOT --flags backend",
 exports[`with overrides 1`] = `
 Object {
   "container": Object {
-    "image": "python:3.8",
+    "image": "python:3.8-buster",
   },
   "continue-on-error": true,
   "env": Object {

--- a/cdk/kraken/test/__snapshots__/labs-application.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/labs-application.test.ts.snap
@@ -40,7 +40,7 @@ jobs:
           cd backend
           pipenv run codecov --root $ROOT --flags backend
     container:
-      image: python:3.8
+      image: python:3.8-buster
     env:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
     services:
@@ -220,7 +220,7 @@ jobs:
           cd backend
           pipenv run codecov --root $ROOT --flags backend
     container:
-      image: python:3.8
+      image: python:3.8-buster
     env:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
     services:


### PR DESCRIPTION
This PR modifies the python 3.8 container used within django check to an underlying OS of buster.