### PR TITLE
[Terraform] Use Route53 directly for LE

### DIFF
--- a/terraform/helm/cert-manager.yaml
+++ b/terraform/helm/cert-manager.yaml
@@ -1,0 +1,9 @@
+installCRDs: true
+
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: ${roleARN}
+
+securityContext:
+  enabled: true
+  fsGroup: 1001

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -13,3 +13,11 @@ module "iam-secret-sync" {
   oidc_issuer_url   = module.eks-production.cluster_oidc_issuer_url
   oidc_provider_arn = module.eks-production.oidc_provider_arn
 }
+
+module "iam-cert-manager" {
+  source            = "./modules/iam"
+  role              = "cert-manager"
+  namespaces        = ["cert-manager"]
+  oidc_issuer_url   = module.eks-production.cluster_oidc_issuer_url
+  oidc_provider_arn = module.eks-production.oidc_provider_arn
+}

--- a/terraform/modules/base_cluster/cert-manager.tf
+++ b/terraform/modules/base_cluster/cert-manager.tf
@@ -12,10 +12,7 @@ resource "helm_release" "cert-manager" {
   namespace  = kubernetes_namespace.cert-manager.metadata[0].name
   // This is set to ensure that cert-manager is working before the CRs are applied
   atomic = true
-  set {
-    name  = "installCRDs"
-    value = true
-  }
+  values = var.cert_manager_values
 }
 
 resource "time_sleep" "cert-manager-cr" {

--- a/terraform/modules/base_cluster/clusterissuer.yaml
+++ b/terraform/modules/base_cluster/clusterissuer.yaml
@@ -11,9 +11,5 @@ spec:
     solvers:
       - selector: {}
         dns01:
-          cnameStrategy: Follow
-          cloudflare:
-            email: pennappslabs@gmail.com
-            apiKeySecretRef:
-              name: cloudflare-api-key-secret
-              key: api-key
+          route53:
+            region: us-east-1

--- a/terraform/modules/base_cluster/variables.tf
+++ b/terraform/modules/base_cluster/variables.tf
@@ -15,3 +15,9 @@ variable "prometheus_values" {
   description = "Values to provide to the Prometheus helm chart"
   type        = list(string)
 }
+
+// Cert Manager values
+variable "cert_manager_values" {
+  description = "Values to provide to the Cert Manager helm chart"
+  type        = list(string)
+}

--- a/terraform/modules/domain/README.md
+++ b/terraform/modules/domain/README.md
@@ -2,7 +2,6 @@
 
 A terraform module to configure basic DNS records for a Penn Labs domain that:
 
-* Allow for LE through our cloudflare proxy domain
 * Point the apex domain to traefik
 * CNAME all subdomains to the apex domain
 * Create SPF, DKIM, and CNAME records to send mail through mailgun

--- a/terraform/modules/domain/main.tf
+++ b/terraform/modules/domain/main.tf
@@ -2,14 +2,6 @@ resource "aws_route53_zone" "domain" {
   name = var.domain
 }
 
-// resource "aws_route53_record" "acme-challenge" {
-//   zone_id = aws_route53_zone.domain.zone_id
-//   name    = "_acme-challenge"
-//   type    = "CNAME"
-//   ttl     = 3600
-//   records = ["_acme-challenge.upenn.club."]
-// }
-
 resource "aws_route53_record" "apex-domain" {
   zone_id = aws_route53_zone.domain.zone_id
   name    = ""

--- a/terraform/modules/domain/main.tf
+++ b/terraform/modules/domain/main.tf
@@ -2,13 +2,13 @@ resource "aws_route53_zone" "domain" {
   name = var.domain
 }
 
-resource "aws_route53_record" "acme-challenge" {
-  zone_id = aws_route53_zone.domain.zone_id
-  name    = "_acme-challenge"
-  type    = "CNAME"
-  ttl     = 3600
-  records = ["_acme-challenge.upenn.club."]
-}
+// resource "aws_route53_record" "acme-challenge" {
+//   zone_id = aws_route53_zone.domain.zone_id
+//   name    = "_acme-challenge"
+//   type    = "CNAME"
+//   ttl     = 3600
+//   records = ["_acme-challenge.upenn.club."]
+// }
 
 resource "aws_route53_record" "apex-domain" {
   zone_id = aws_route53_zone.domain.zone_id

--- a/terraform/production-cluster.tf
+++ b/terraform/production-cluster.tf
@@ -37,7 +37,7 @@ module "production-cluster" {
   })]
   prometheus_values = [file("helm/prometheus.yaml")]
   cert_manager_values = [templatefile("helm/cert-manager.yaml", {
-      roleARN = module.iam-cert-manager.role-arn
+    roleARN = module.iam-cert-manager.role-arn
   })]
 }
 

--- a/terraform/production-cluster.tf
+++ b/terraform/production-cluster.tf
@@ -36,6 +36,9 @@ module "production-cluster" {
     role_arn = module.iam-secret-sync.role-arn
   })]
   prometheus_values = [file("helm/prometheus.yaml")]
+  cert_manager_values = [templatefile("helm/cert-manager.yaml", {
+      roleARN = module.iam-cert-manager.role-arn
+  })]
 }
 
 

--- a/terraform/route53.tf
+++ b/terraform/route53.tf
@@ -18,3 +18,34 @@ resource "aws_route53_record" "bastion" {
   ttl     = 3600
   records = [aws_instance.bastion.public_dns]
 }
+
+
+// Cert-Manager IAM
+data "aws_iam_policy_document" "cert-manager-iam" {
+  statement {
+    actions = [
+      "route53:GetChange",
+    ]
+    resources = ["arn:aws:route53:::change/*"]
+  }
+  statement {
+    actions = [
+      "route53:ChangeResourceRecordSets",
+      "route53:ListResourceRecordSets",
+    ]
+    resources = ["arn:aws:route53:::hostedzone/*"]
+  }
+  statement {
+    actions = [
+      "route53:ListHostedZonesByName",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "cert-manager-iam" {
+  name = "iam"
+  role = module.iam-cert-manager.role-id
+
+  policy = data.aws_iam_policy_document.cert-manager-iam.json
+}


### PR DESCRIPTION
This PR modifies our infrastructure so that cert-manager in the cluster directly makes DNS changes in Route53 rather than the weird CNAME redirect we were doing using upenn.club for lets encrypt challenges.