### PR TITLE
[Kraken] Fix PyPI Publish Job

### DIFF
--- a/cdk/kraken/CHANGELOG.md
+++ b/cdk/kraken/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## X.Y.Z (UNRELEASED)
+
+* Modify PyPI python versions to be strings
+* Modify PyPI to correctly publish
+* Migrate to ts-dedent
+
 ## 0.6.4 (2021-10-04)
 
 * Modify PyPI publish to use poetry

--- a/cdk/kraken/package.json
+++ b/cdk/kraken/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "cdkactions": "^0.2.0",
     "constructs": "^3.2.80",
-    "dedent-js": "^1.0.1"
+    "ts-dedent": "^2.2.0"
   },
   "bundledDependencies": [],
   "keywords": [

--- a/cdk/kraken/src/cdk.ts
+++ b/cdk/kraken/src/cdk.ts
@@ -1,6 +1,6 @@
 import { CheckoutJob, Workflow, Stack, WorkflowProps } from 'cdkactions';
 import { Construct } from 'constructs';
-import * as dedent from 'dedent-js';
+import dedent from 'ts-dedent';
 
 /**
  * Optional props to configure the CDK publish stack.

--- a/cdk/kraken/src/deploy.ts
+++ b/cdk/kraken/src/deploy.ts
@@ -1,5 +1,5 @@
 import { CheckoutJob, Workflow, JobProps } from 'cdkactions';
-import * as dedent from 'dedent-js';
+import dedent from 'ts-dedent';
 
 /**
  * Optional props to configure the deploy job.

--- a/cdk/kraken/src/django.ts
+++ b/cdk/kraken/src/django.ts
@@ -1,5 +1,5 @@
 import { CheckoutJob, Workflow, StepsProps, JobProps } from 'cdkactions';
-import * as dedent from 'dedent-js';
+import dedent from 'ts-dedent';
 import { buildId, buildName } from './utils';
 
 /**

--- a/cdk/kraken/src/integration-tests.ts
+++ b/cdk/kraken/src/integration-tests.ts
@@ -1,5 +1,5 @@
 import { Workflow, JobProps, CheckoutJob } from 'cdkactions';
-import * as dedent from 'dedent-js';
+import dedent from 'ts-dedent';
 import { PostIntegrationPublishJob } from './postintegrationimagepublishjob';
 import { buildId, buildName } from './utils';
 

--- a/cdk/kraken/src/pypi.ts
+++ b/cdk/kraken/src/pypi.ts
@@ -14,9 +14,9 @@ export interface PyPIPublishStackProps {
 
   /**
    * List of python versions to run tox with.
-   * @default 3.6, 3.7, 3.8, 3.9
+   * @default "3.7", "3.8", "3.9", "3.10"
    */
-  pythonMatrixVersions?: number[];
+  pythonMatrixVersions?: string[];
 }
 
 /**
@@ -34,7 +34,7 @@ export class PyPIPublishStack extends Stack {
     // Build config
     const fullConfig: Required<PyPIPublishStackProps> = {
       pythonVersion: '3.8',
-      pythonMatrixVersions: [3.6, 3.7, 3.8, 3.9],
+      pythonMatrixVersions: ['3.7', '3.8', '3.9', '3.10'],
       ...config,
     };
 

--- a/cdk/kraken/src/pypi.ts
+++ b/cdk/kraken/src/pypi.ts
@@ -1,6 +1,6 @@
-import * as dedent from 'dedent-js';
 import { CheckoutJob, Workflow, Stack, WorkflowProps } from 'cdkactions';
 import { Construct } from 'constructs';
+import dedent from 'ts-dedent';
 
 /**
  * Optional props to configure the PyPI publish stack.

--- a/cdk/kraken/src/pypi.ts
+++ b/cdk/kraken/src/pypi.ts
@@ -89,9 +89,10 @@ export class PyPIPublishStack extends Stack {
       steps: [
         {
           name: 'Verify tag',
+          shell: 'bash',
           run: dedent`GIT_TAG=\${GITHUB_REF/refs\\/tags\\//}
           LIBRARY_VERSION=$(poetry version -s)
-          if [[ "$GIT_TAG" != LIBRARY_VERSION ]]; then exit 1; fi`,
+          if [[ "$GIT_TAG" != "$LIBRARY_VERSION" ]]; then echo "Tag ($GIT_TAG) does not match poetry version ($LIBRARY_VERSION)"; exit 1; fi`,
         },
         {
           name: 'Build',
@@ -101,8 +102,8 @@ export class PyPIPublishStack extends Stack {
           name: 'Publish',
           run: 'poetry publish',
           env: {
-            POETRY_PYPI_TOKEN_PYPI: '${{ secrets.PYPI_PASSWORD }}'
-          }
+            POETRY_PYPI_TOKEN_PYPI: '${{ secrets.PYPI_PASSWORD }}',
+          },
         },
       ],
     });

--- a/cdk/kraken/src/react.ts
+++ b/cdk/kraken/src/react.ts
@@ -1,5 +1,5 @@
 import { Workflow, JobProps, CheckoutJob } from 'cdkactions';
-import * as dedent from 'dedent-js';
+import dedent from 'ts-dedent';
 import { buildId, buildName } from './utils';
 
 /**

--- a/cdk/kraken/test/__snapshots__/pypi.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/pypi.test.ts.snap
@@ -16,10 +16,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
+          - \\"3.7\\"
+          - \\"3.8\\"
+          - \\"3.9\\"
+          - \\"3.10\\"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python \${{ matrix.python-version }}
@@ -41,10 +41,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Verify tag
+        shell: bash
         run: |-
           GIT_TAG=\${GITHUB_REF/refs\\\\/tags\\\\//}
           LIBRARY_VERSION=$(poetry version -s)
-          if [[ \\"$GIT_TAG\\" != LIBRARY_VERSION ]]; then exit 1; fi
+          if [[ \\"$GIT_TAG\\" != \\"$LIBRARY_VERSION\\" ]]; then echo \\"Tag ($GIT_TAG) does not match poetry version ($LIBRARY_VERSION)\\"; exit 1; fi
       - name: Build
         run: poetry build
       - name: Publish

--- a/cdk/kraken/yarn.lock
+++ b/cdk/kraken/yarn.lock
@@ -1670,11 +1670,6 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-dedent-js@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dedent-js/-/dedent-js-1.0.1.tgz#bee5fb7c9e727d85dffa24590d10ec1ab1255305"
-  integrity sha1-vuX7fJ5yfYXf+iRZDRDsGrElUwU=
-
 deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -5423,6 +5418,11 @@ ts-dedent@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.0.0.tgz#47c5eb23d9096f3237cc413bc82d387d36dbe690"
   integrity sha512-DfxKjSFQfw9+uf7N9Cy8Ebx9fv5fquK4hZ6SD3Rzr+1jKP6AVA6H8+B5457ZpUs0JKsGpGqIevbpZ9DMQJDp1A==
+
+ts-dedent@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/ts-dedent/-/ts-dedent-2.2.0.tgz#39e4bd297cd036292ae2394eb3412be63f563bb5"
+  integrity sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==
 
 ts-jest@^26.4.4:
   version "26.4.4"


### PR DESCRIPTION
This PR:
* Fixes the publish job within the PyPI stack by forcing GH Actions to use bash (this was annoying to find)
* Modifies python versions to be strings (3.10 != 3.1) and removes 3.6 from the defaults since it's almost EOL
* Migrates the project to ts-dedent to conform with cdkactions