### PR TITLE
:new: Add libc-dev to django-base

### DIFF
--- a/docker/django-base/Dockerfile
+++ b/docker/django-base/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.10.1-slim-bullseye
 LABEL maintainer="Penn Labs"
 
 # Install build dependencies
-RUN apt-get update && apt-get install --no-install-recommends -y gcc libpq-dev \
+RUN apt-get update && apt-get install --no-install-recommends -y gcc libpq-dev libc-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy mime definitions


### PR DESCRIPTION
`libc-dev` needed for `psycopg2`