### PR TITLE
[Terraform] Expand VPC + Managed EKS Nodes

### DIFF
--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -16,6 +16,13 @@ module "eks-production" {
       groups   = ["system:masters"]
     },
   ]
+  map_users = [
+    {
+      userarn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/platform"
+      username = "platform"
+      groups   = ["system:masters"]
+    },
+  ]
   worker_groups_launch_template = [
     {
       name                    = "spot-1"

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -25,11 +25,11 @@ module "eks-production" {
   ]
   node_groups = {
     spot = {
-      desired_capacity = 10
-      max_capacity     = 10
-      min_capacity     = 10
+      desired_capacity = local.k8s_cluster_size
+      max_capacity     = local.k8s_cluster_size
+      min_capacity     = local.k8s_cluster_size
 
-      instance_types = ["t3.medium"]
+      instance_types = ["r5d.large"]
       capacity_type  = "SPOT"
     }
   }

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -23,18 +23,16 @@ module "eks-production" {
       groups   = ["system:masters"]
     },
   ]
-  worker_groups_launch_template = [
-    {
-      name                    = "spot-1"
-      override_instance_types = ["t3.medium"]
-      spot_instance_pools     = 1
-      asg_max_size            = local.k8s_cluster_size
-      asg_desired_capacity    = local.k8s_cluster_size
-      kubelet_extra_args      = "--node-labels=node.kubernetes.io/lifecycle=spot"
-      bootstrap_extra_args    = "--use-max-pods false"
-      public_ip               = true
-    },
-  ]
+  node_groups = {
+    spot = {
+      desired_capacity = 10
+      max_capacity     = 10
+      min_capacity     = 10
+
+      instance_types = ["t3.medium"]
+      capacity_type  = "SPOT"
+    }
+  }
   tags = {
     created-by = "terraform"
   }

--- a/terraform/helm/aws-node-termination-handler.yaml
+++ b/terraform/helm/aws-node-termination-handler.yaml
@@ -4,7 +4,7 @@ enableSpotInterruptionDraining: "true"
 # nodeSelector tells both linux and windows daemonsets where to place the node-termination-handler
 # pods. By default, this value is empty and every node will receive a pod.
 nodeSelector:
-  node.kubernetes.io/lifecycle: spot
+  eks.amazonaws.com/capacityType: SPOT
 
 enablePrometheusServer: true
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -28,7 +28,7 @@ locals {
     "jonathan",
   ])
   k8s_cluster_name = "production"
-  k8s_cluster_size = 10
+  k8s_cluster_size = 3
   vault_ami        = "ami-0eec2c28d4dd94628"
   domains = toset([
     "ohq.io",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,7 @@ locals {
     "pennlabs.org",
     "pennmobile.org",
   ])
-  traefik_lb_name = "a3b77cc4561e649d4bcc2a89e1b63d7d"
+  traefik_lb_name = "acf3fd952315e4e6f90772849116da8d"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,6 +43,7 @@ locals {
     "pennmobile.org",
   ])
   traefik_lb_name = "acf3fd952315e4e6f90772849116da8d"
+  vpc_cidr        = "10.0.0.0/16"
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -5,11 +5,14 @@ module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "3.11.0"
 
-  name                 = "vpc"
-  cidr                 = "10.0.0.0/16"
-  azs                  = data.aws_availability_zones.available.names
-  private_subnets      = ["10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"]
-  public_subnets       = ["10.0.48.0/20", "10.0.64.0/20", "10.0.80.0/20"]
+  name = "vpc"
+  cidr = "10.0.0.0/16"
+  azs  = data.aws_availability_zones.available.names
+  # Generate 6 non-overlapping subnets for our VPC
+  # The 4 here represents that we want to create subnets of size: vpc subnet mask + 4
+  # = 16 + 4 = 20. This results in 2^(32-20)=2^12=4096 IPs per subnet.
+  private_subnets      = [for offset in [0, 1, 2] : cidrsubnet(local.vpc_cidr, 4, offset)]
+  public_subnets       = [for offset in [3, 4, 5] : cidrsubnet(local.vpc_cidr, 4, offset)]
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -8,8 +8,8 @@ module "vpc" {
   name                 = "vpc"
   cidr                 = "10.0.0.0/16"
   azs                  = data.aws_availability_zones.available.names
-  private_subnets      = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
-  public_subnets       = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+  private_subnets      = ["10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"]
+  public_subnets       = ["10.0.48.0/20", "10.0.64.0/20", "10.0.80.0/20"]
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -8,11 +8,9 @@ module "vpc" {
   name = "vpc"
   cidr = "10.0.0.0/16"
   azs  = data.aws_availability_zones.available.names
-  # Generate 6 non-overlapping subnets for our VPC
-  # The 4 here represents that we want to create subnets of size: vpc subnet mask + 4
-  # = 16 + 4 = 20. This results in 2^(32-20)=2^12=4096 IPs per subnet.
-  private_subnets      = [for offset in [0, 1, 2] : cidrsubnet(local.vpc_cidr, 4, offset)]
-  public_subnets       = [for offset in [3, 4, 5] : cidrsubnet(local.vpc_cidr, 4, offset)]
+  # Generate 6 non-overlapping subnets for our VPC. This results in 2^(32-20)=2^12=4096 IPs per subnet.
+  private_subnets      = ["10.0.0.0/20", "10.0.16.0/20", "10.0.32.0/20"]
+  public_subnets       = ["10.0.48.0/20", "10.0.64.0/20", "10.0.80.0/20"]
   enable_nat_gateway   = true
   single_nat_gateway   = true
   enable_dns_hostnames = true


### PR DESCRIPTION
This PR:
* Moves us over to managed EKS node groups rather than the "self-managed" version through the EKS terraform module
* Grants the `platform` IAM user admin access to the EKS cluster (so it can view details in the web console)
* Expands our VPC so we can put more pods on our EKS nodes (I can't believe I thought 256 IPs per availability zone were enough)
* Switches us to using r5d.large instances for our EKS cluster to save (hopefully) lots of money

Note that the traefik load balancer changed because our entire cluster had to be rebuilt on the new VPC subnets