### PR TITLE
[Terraform] Eliminate more Tech Debt

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/cyrilgdn/postgresql" {
   version     = "1.15.0"
-  constraints = "~> 1.8"
+  constraints = "~> 1.15"
   hashes = [
     "h1:ycRZwv0xuEW14dbtSQVxJKkaO5XaiI3zIkAPkpxHUQ0=",
     "zh:047711b33daf269eb61e5ff572a78c3b28213fecfa7ebe85f2d30b2fd60dba4d",
@@ -24,21 +24,21 @@ provider "registry.terraform.io/cyrilgdn/postgresql" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.74.1"
-  constraints = ">= 2.0.0, >= 3.63.0, >= 3.72.0, ~> 3.74"
+  version     = "3.74.2"
+  constraints = ">= 2.0.0, >= 3.0.0, >= 3.63.0, >= 3.72.0, ~> 3.74"
   hashes = [
-    "h1:0/ImOh63jJHOqiA165x+99N+MR0Rz7x4Nlcbnpys4Ww=",
-    "zh:2de9a8c19e07ea3b12c3fe5fe23ffa71354f90683d1f3ded41f2f318e8bad401",
-    "zh:3f651572f9ad067e119ed083d25455627ae121d36e737823f1d89445949f8ca0",
-    "zh:468c5954ea646e8edbf70c5a3dbce3d9591a47259f3cf3bdfb2c8728a5e3a083",
-    "zh:5b379f4803268d3a2cde0bd8a2b6b0a3752e0a22d2cb15a9a28c6a8852d17840",
-    "zh:5f1271620def1e199afad2377e37ab194f5d5ea51ff804c0e7d468fc4a48b741",
-    "zh:770783d8d743f28ecaeaf7485f9d602071d610278e33347a692ebb75ae690a8f",
-    "zh:aecfa7b52f39cbfb1ef53576935ad6cc05deebf82d0b8b6b82c10727469d1c85",
-    "zh:c905af45fc8cb64fe566c5b35241baf5e5850e137ebbd59a3298321648d05046",
-    "zh:d7dabb6a110073c8adaf34af288a485714b4be7185304d491f042827a77f9d5f",
-    "zh:e8ccc2ef2465164ce467f32d58e5ffad74da92cc3733551aef5e0d839532e3d4",
-    "zh:f1c2c9145383ab8675eab68398b53cf33edb2665d64ef2e48e0444771fa5849e",
+    "h1:TryIinyNf2gFkYA/d4hD0a76mPSvyl9rMUHePqs6cgs=",
+    "zh:2b1df436ec034ae9416b23b95efd192b2fe271a7c8595493329dcde8e452c036",
+    "zh:3aba9abd4bc8a904378b1f852d025a397ef74f0dbe59134a06fc5abebb259efc",
+    "zh:45700f37e3a97c5b3a8d5d2ec79ae7a8671be8893a6a6c38ae069888d13c20fe",
+    "zh:5b2ca0fde7f9b723018528ea21b151f2ada360a435ef2dcfb666d7fe686b2845",
+    "zh:785c52c6b4724873723b77c78e66024dc7ad951eeacb44a8c0cab2dd3c0f9828",
+    "zh:8b50a307f3324c4e31813abdb08a21c666e302e4c0496d9f8015ae76327cafb4",
+    "zh:ab78cab83e7806030c1b1e4943a6edb149a901380a1a5f7bceb1a1f41098e4c5",
+    "zh:c06a7fbffbbfa7b407990091869c0642dc9e38217da2895b49b42892e86eada6",
+    "zh:e046e30e24b3b95ca8ec0ecac562ac8a47e86f9db0efa460e50c2afce07e084e",
+    "zh:ef02426419de15931bcdfb400d914d720639607415ac623c04cdf425c71ade41",
+    "zh:fb1990e9e162cf1837792e4886a4b6dcb3ffdd511d1ba4b56118127525504032",
   ]
 }
 
@@ -58,26 +58,6 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
     "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
     "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
     "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/github" {
-  version = "4.17.0"
-  hashes = [
-    "h1:sZeGxNQ/Xt9hbAPiH3s+JPFtdYA5fH3GwdgzuPf6uJ0=",
-    "zh:172fc888630839a4e2097fa2e5fc490ca2e5c5639b8c0ed8cd8aa4656382a270",
-    "zh:18d7a0e7c9083516a9ed03eab31d29d625ffc9ba2364ecb8669b6a1c4a6f5154",
-    "zh:1a3f97c624371d63c2e9797dcec16792cbbecc64f533d5dfe68e675c5d900a57",
-    "zh:5a18b3ab9270a3c679c992aa48651d9a8a2135d961bfba401f534bce77e358a9",
-    "zh:5c7c9c3b4592f118367bc9577e708ec6e4ec747a992093421c84544c893b76e1",
-    "zh:72fa658a47e250f5f71cb4655401c08fad4d64f9728608a3c8186ed98967cf4b",
-    "zh:81eb8825e1c0520e1dc8ac001c2c723176cce45799e663f9c2d8e66330c36518",
-    "zh:987375ee8f6805dfc896b5916857d3426dbd3ac9fbdbe500bde4fc20257027a4",
-    "zh:b88f9e18b14d42f0918df915a713540854636ac665572a02481ce01ac16a200e",
-    "zh:c66c7979d1cede2ba574e18c5642a3d3c89716c73d3ba5f74c2cdee4503b8ead",
-    "zh:cd2e26bb885e0936bcd6db7e27610af0887fb5646746edbb0ec53d8c50184c31",
-    "zh:d0d796840d949e9139f7767eb23eb2b2afa592f724cbad2dca509617c80cd0c6",
-    "zh:ecf9dfadfa291f641580d6a3d0fe6c3b12507f5eebb72ead4f59786c53188c9b",
   ]
 }
 
@@ -101,27 +81,27 @@ provider "registry.terraform.io/hashicorp/helm" {
 }
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
-  version     = "2.7.1"
-  constraints = ">= 1.11.1, ~> 2.7"
+  version     = "2.8.0"
+  constraints = "~> 2.7"
   hashes = [
-    "h1:Df9MZxqgXueXVObeAiPPDQ5aLwQ2bJ2r1gul/IYSxeg=",
-    "zh:0da320fd81ece6696f7cceda35e459ee97cae8955088af38fc7f2feab1dce924",
-    "zh:37d304b8b992518c9c12e8f10437b9d4a0cc5a823c9421ac794ad2347c4d1122",
-    "zh:3d4e12fb9588c3b2e782d392fea758c6982e5d653154bec951e949155bcbc169",
-    "zh:6bb32b8d5cccf3e3ae7c124ed27df76dc7653ca760c132addeee15272630c930",
-    "zh:94775153b90e285876fc17261e8f5338a1ff732f4133336cc68754acb74570b6",
-    "zh:a665d1336765cdf8620a8797fd4e7e3cecf789e96e59ba80634336a4390df377",
-    "zh:aa8b35e9958cb89f01c115e8866a07d5468fb53f1c227d673e94f7ee8fb76242",
-    "zh:b7a571336387d773a74ed6eefa3843ff78d3662f2745c99c95008002a1341662",
-    "zh:c50d661782175d50ea4952fe943b0e4a3e33c27aa69e5ff21b3cbfa513e90d0a",
-    "zh:e0999b349cc772c75876adbc2a13b5dc256d3ecd7e4aa91baee5fdfcecaa7465",
-    "zh:e1399aec06a7aa98e9b0f64b4281697247f338a8a40b79f5f6ebfd43bf4ce1e2",
+    "h1:UZCCMTH49ziz6YDV5oCCoOHypOxZWvzc59IfZxVdWeI=",
+    "zh:0cf42c17c05ae5f0f5eb4b2c375dd2068960b97392e50823e47b2cee7b5e01be",
+    "zh:29e3751eceae92c7400a17fe3a5394ed761627bcadfda66e7ac91d6485c37927",
+    "zh:2d95584504c651e1e2e49fbb5fae1736e32a505102c3dbd2c319b26884a7d3d5",
+    "zh:4a5f1d915c19e7c7b4f04d7d68f82db2c872dad75b9e6f33a6ddce43aa160405",
+    "zh:4b959187fd2c884a4c6606e1c4edc7b506ec4cadb2742831f37aca1463eb349d",
+    "zh:5e76a2b81c93d9904d50c2a703845f79d2b080c2f87c07ef8f168592033d638f",
+    "zh:c5aa21a7168f96afa4b4776cbd7eefd3e1f47d48430dce75c7f761f2d2fac77b",
+    "zh:d45e8bd98fc6752ea087e744efdafb209e7ec5a4224f9affee0a24fb51d26bb9",
+    "zh:d4739255076ed7f3ac2a06aef89e8e48a87667f3e470c514ce2185c0569cc1fb",
+    "zh:dbd2f11529a422ffd17040a70c0cc2802b7f1be2499e976dc22f1138d022b1b4",
+    "zh:dbd5357082b2485bb9978bce5b6d508d6b431d15c53bfa1fcc2781131826b5d8",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/local" {
   version     = "2.1.0"
-  constraints = ">= 1.3.0, >= 1.4.0"
+  constraints = ">= 1.3.0"
   hashes = [
     "h1:EYZdckuGU3n6APs97nS2LxZm3dDtGqyM4qaIvsmac8o=",
     "zh:0f1ec65101fa35050978d483d6e8916664b7556800348456ff3d09454ac1eae2",
@@ -139,8 +119,7 @@ provider "registry.terraform.io/hashicorp/local" {
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.1.0"
-  constraints = ">= 2.1.0"
+  version = "3.1.0"
   hashes = [
     "h1:vpC6bgUQoJ0znqIKVFevOdq+YQw42bRq0u+H3nto8nA=",
     "zh:02a1675fd8de126a00460942aaae242e65ca3380b5bb192e8773ef3da9073fd2",
@@ -159,7 +138,7 @@ provider "registry.terraform.io/hashicorp/null" {
 
 provider "registry.terraform.io/hashicorp/random" {
   version     = "3.1.0"
-  constraints = ">= 2.1.0, ~> 3.0"
+  constraints = "~> 3.1"
   hashes = [
     "h1:BZMEPucF+pbu9gsPk0G0BHx7YP04+tKdq2MrRDF1EDM=",
     "zh:2bbb3339f0643b5daa07480ef4397bd23a79963cc364cdfbb4e86354cb7725bc",
@@ -178,7 +157,7 @@ provider "registry.terraform.io/hashicorp/random" {
 
 provider "registry.terraform.io/hashicorp/template" {
   version     = "2.2.0"
-  constraints = ">= 2.0.0, >= 2.1.0"
+  constraints = ">= 2.0.0"
   hashes = [
     "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
     "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
@@ -196,7 +175,7 @@ provider "registry.terraform.io/hashicorp/template" {
 
 provider "registry.terraform.io/hashicorp/time" {
   version     = "0.7.2"
-  constraints = "~> 0.6"
+  constraints = "~> 0.7"
   hashes = [
     "h1:YYLAfhMFP5nhV2iZPslqsLkZN+6sZo7gMJW7pLcLfM8=",
     "zh:0bbe0158c2a9e3f5be911b7e94477586110c51746bb13d102054f22754565bda",
@@ -253,7 +232,7 @@ provider "registry.terraform.io/hashicorp/vault" {
 
 provider "registry.terraform.io/integrations/github" {
   version     = "4.20.0"
-  constraints = "~> 4.0"
+  constraints = "~> 4.20"
   hashes = [
     "h1:8aEltkf7TY+fPzD6t1jjk5zVEsj7FHLzhNFsUpZhohA=",
     "zh:1501c3ccaf624cf6d9d311eb59f911fa0cf431d4728af3b103e01c0eb4201efb",
@@ -269,26 +248,5 @@ provider "registry.terraform.io/integrations/github" {
     "zh:f40c44faa01d7f615a67711ebd01b8175ffc2121c35483905c1b1afedc1f1af5",
     "zh:f4c2f8db3902803c2e06b3c36c58cb847f893e775e5855165300d8baa756199a",
     "zh:fd329d9663e710ab6d35465c16a0a085463039740cb34458ee9f47b05402c736",
-  ]
-}
-
-provider "registry.terraform.io/terraform-aws-modules/http" {
-  version     = "2.4.1"
-  constraints = ">= 2.4.1"
-  hashes = [
-    "h1:ZnkXcawrIr611RvZpoDzbtPU7SVFyHym+7p1t+PQh20=",
-    "zh:0111f54de2a9815ded291f23136d41f3d2731c58ea663a2e8f0fef02d377d697",
-    "zh:0740152d76f0ccf54f4d0e8e0753739a5233b022acd60b5d2353d248c4c17204",
-    "zh:569518f46809ec9cdc082b4dfd4e828236eee2b50f87b301d624cfd83b8f5b0d",
-    "zh:7669f7691de91eec9f381e9a4be81aa4560f050348a86c6ea7804925752a01bb",
-    "zh:81cd53e796ec806aca2d8e92a2aed9135661e170eeff6cf0418e54f98816cd05",
-    "zh:82f01abd905090f978b169ac85d7a5952322a5f0f460269dd981b3596652d304",
-    "zh:9a235610066e0f7e567e69c23a53327271a6fc568b06bf152d8fe6594749ed2b",
-    "zh:aeabdd8e633d143feb67c52248c85358951321e35b43943aeab577c005abd30a",
-    "zh:c20d22dba5c79731918e7192bc3d0b364d47e98a74f47d287e6cc66236bc0ed0",
-    "zh:c4fea2cb18c31ed7723deec5ebaff85d6795bb6b6ed3b954794af064d17a7f9f",
-    "zh:e21e88b6e7e55b9f29b046730d9928c65a4f181fd5f60a42f1cd41b46a0a938d",
-    "zh:eddb888a74dea348a0acdfee13a08875bacddde384bd9c28342a534269665568",
-    "zh:f46d5f1403b8d8dfafab9bdd7129d3080bb62a91ea726f477fd43560887b8c4a",
   ]
 }

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -24,21 +24,21 @@ provider "registry.terraform.io/cyrilgdn/postgresql" {
 }
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.74.0"
-  constraints = ">= 2.0.0, ~> 3.18, >= 3.40.0, >= 3.56.0, >= 3.63.0"
+  version     = "3.74.1"
+  constraints = ">= 2.0.0, >= 3.63.0, >= 3.72.0, ~> 3.74"
   hashes = [
-    "h1:YNOblHBUf+XTjGTfIIsAMGp4weXB+tmQrMPCrpmM1/U=",
-    "zh:00767509c13c0d1c7ad6af702c6942e6572aa6d529b40a00baacc0e73faafea2",
-    "zh:03aafdc903ad49c2eda03889f927f44212674c50e475a9c6298850381319eec2",
-    "zh:2de8a6a97b180f909d652f215125aa4683e99db15fcf3b28d62e3d542f875ed6",
-    "zh:3ac29ebc3af99028f4230a79f56606a0c2954b68767bd749b921a76eb4f3bd30",
-    "zh:50add2e2d118a15a644360eabc5a34cec59f2560b491f8fabf9c52ab83ca7b09",
-    "zh:85dd8e81910ab79f841a4a595fdd8ac358fbfe460956144afb0be3d81f91fe10",
-    "zh:895de83d0f0941fde31bfc53fa6b1ea276901f006bec221bbdee4771a04f3693",
-    "zh:a15c9724aac52d1ba5001d2d83e42843099b52b1638ea29d84e20be0f45fa4f1",
-    "zh:c982a64463bd73e9bff2589de214b1de0a571438d9015001f9eae45cfc3a2559",
-    "zh:e9ef973c18078324e43213ea1252c12b9441e566bf054ddfdbff5dd62f3035d9",
-    "zh:f297e705b0f339c8baa27ae70db5df9aa6578adfe1ea3d2ba8edc186512464eb",
+    "h1:0/ImOh63jJHOqiA165x+99N+MR0Rz7x4Nlcbnpys4Ww=",
+    "zh:2de9a8c19e07ea3b12c3fe5fe23ffa71354f90683d1f3ded41f2f318e8bad401",
+    "zh:3f651572f9ad067e119ed083d25455627ae121d36e737823f1d89445949f8ca0",
+    "zh:468c5954ea646e8edbf70c5a3dbce3d9591a47259f3cf3bdfb2c8728a5e3a083",
+    "zh:5b379f4803268d3a2cde0bd8a2b6b0a3752e0a22d2cb15a9a28c6a8852d17840",
+    "zh:5f1271620def1e199afad2377e37ab194f5d5ea51ff804c0e7d468fc4a48b741",
+    "zh:770783d8d743f28ecaeaf7485f9d602071d610278e33347a692ebb75ae690a8f",
+    "zh:aecfa7b52f39cbfb1ef53576935ad6cc05deebf82d0b8b6b82c10727469d1c85",
+    "zh:c905af45fc8cb64fe566c5b35241baf5e5850e137ebbd59a3298321648d05046",
+    "zh:d7dabb6a110073c8adaf34af288a485714b4be7185304d491f042827a77f9d5f",
+    "zh:e8ccc2ef2465164ce467f32d58e5ffad74da92cc3733551aef5e0d839532e3d4",
+    "zh:f1c2c9145383ab8675eab68398b53cf33edb2665d64ef2e48e0444771fa5849e",
   ]
 }
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,7 +6,6 @@ We use [Terraform](https://www.terraform.io/docs/index.html) to manage our infra
 
 |                     | Description                                                                                                                                                                       |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CF_API_KEY          | The [Global API Key](https://cert-manager.io/docs/configuration/acme/dns01/cloudflare/#api-keys) of the Penn Labs Cloudflare account                                              |
 | GH_PERSONAL_TOKEN   | A [GitHub Personal Access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) of the Penn Labs Admin account |
 | GF_GH_CLIENT_ID     | The Client ID to the Grafana Penn Labs OAuth2 application on Github                                                                                                               |
 | GF_SLACK_URL        | Slack notification URL used for Grafana notifications                                                                                                                             |

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,4 +1,5 @@
 module "tfstate_backend" {
-  source = "git::https://github.com/cloudposse/terraform-aws-tfstate-backend.git?ref=tags/0.28.0"
-  name   = "pennlabs-terraform"
+  source  = "cloudposse/tfstate-backend/aws"
+  version = "0.38.1"
+  name    = "pennlabs-terraform"
 }

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -7,21 +7,6 @@ module "eks-production" {
   cluster_version = "1.21"
   subnet_ids      = module.vpc.private_subnets
   vpc_id          = module.vpc.vpc_id
-
-  # map_roles = [
-  #   {
-  #     rolearn  = aws_iam_role.kubectl.arn
-  #     username = aws_iam_role.kubectl.name
-  #     groups   = ["system:masters"]
-  #   },
-  # ]
-  # map_users = [
-  #   {
-  #     userarn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/platform"
-  #     username = "platform"
-  #     groups   = ["system:masters"]
-  #   },
-  # ]
   eks_managed_node_groups = {
     spot = {
       desired_size = local.k8s_cluster_size

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -61,7 +61,7 @@ resource "null_resource" "eks-bootstrap" {
 
     # TODO: docker pull secrets
     command = <<EOF
-    kubectl patch configmap/aws-auth --patch \"${local.aws_auth_configmap_yaml}\" -n kube-system --kubeconfig <(echo $KUBECONFIG | base64 --decode);
+    kubectl patch configmap/aws-auth --patch "${local.aws_auth_configmap_yaml}" -n kube-system --kubeconfig <(echo $KUBECONFIG | base64 --decode);
     kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true --kubeconfig <(echo $KUBECONFIG | base64 --decode)
     EOF
   }

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -44,7 +44,6 @@ resource "null_resource" "eks-bootstrap" {
       KUBECONFIG = base64encode(local.kubeconfig)
     }
 
-    # TODO: docker pull secrets
     command = <<EOF
     kubectl patch configmap/aws-auth --patch "${local.aws_auth_configmap_yaml}" -n kube-system --kubeconfig <(echo $KUBECONFIG | base64 --decode);
     kubectl set env daemonset aws-node -n kube-system ENABLE_PREFIX_DELEGATION=true --kubeconfig <(echo $KUBECONFIG | base64 --decode);

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -35,13 +35,13 @@ data "aws_eks_cluster_auth" "production" {
 
 resource "null_resource" "eks-bootstrap" {
   triggers = {
-    kubeconfig = base64encode(local.kubeconfig)
+    kubeconfig = module.eks-production.cluster_endpoint
   }
 
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     environment = {
-      KUBECONFIG = self.triggers.kubeconfig
+      KUBECONFIG = base64encode(local.kubeconfig)
     }
 
     # TODO: docker pull secrets

--- a/terraform/helm/vault-secret-sync.yaml
+++ b/terraform/helm/vault-secret-sync.yaml
@@ -1,6 +1,5 @@
 namespaces:
   - default
-  - cert-manager
   # - staging
 
 role_arn: ${role_arn}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,6 +44,31 @@ locals {
   ])
   traefik_lb_name = "acf3fd952315e4e6f90772849116da8d"
   vpc_cidr        = "10.0.0.0/16"
+  kubeconfig = yamlencode({
+    apiVersion      = "v1"
+    kind            = "Config"
+    current-context = "terraform"
+    clusters = [{
+      name = module.eks-production.cluster_id
+      cluster = {
+        certificate-authority-data = module.eks-production.cluster_certificate_authority_data
+        server                     = module.eks-production.cluster_endpoint
+      }
+    }]
+    contexts = [{
+      name = "terraform"
+      context = {
+        cluster = module.eks-production.cluster_id
+        user    = "terraform"
+      }
+    }]
+    users = [{
+      name = "terraform"
+      user = {
+        token = data.aws_eks_cluster_auth.production.token
+      }
+    }]
+  })
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -69,7 +69,6 @@ locals {
       }
     }]
   })
-  # TODO: this isn't working
   aws_auth_configmap_yaml = <<-EOT
   ${chomp(module.eks-production.aws_auth_configmap_yaml)}
       - rolearn: ${aws_iam_role.kubectl.arn}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,7 @@ locals {
     "pennlabs.org",
     "pennmobile.org",
   ])
-  traefik_lb_name = "acf3fd952315e4e6f90772849116da8d"
+  traefik_lb_name = "a1ee5ea4aab3543feaedfdb80587d360"
   vpc_cidr        = "10.0.0.0/16"
   kubeconfig = yamlencode({
     apiVersion      = "v1"
@@ -69,6 +69,19 @@ locals {
       }
     }]
   })
+  # TODO: this isn't working
+  aws_auth_configmap_yaml = <<-EOT
+  ${chomp(module.eks-production.aws_auth_configmap_yaml)}
+      - rolearn: ${aws_iam_role.kubectl.arn}
+        username: ${aws_iam_role.kubectl.name}
+        groups:
+          - system:masters
+    mapUsers: |
+      - userarn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/platform
+        username: platform
+        groups:
+          - system:masters
+      EOT
 }
 
 data "aws_caller_identity" "current" {}

--- a/terraform/modules/vault/README.md
+++ b/terraform/modules/vault/README.md
@@ -8,7 +8,6 @@ Defines the following inputs to store within vault. These variables can be provi
 
 |                     | Description                                                                                                                                                                       |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| CF_API_KEY          | The [Global API Key](https://cert-manager.io/docs/configuration/acme/dns01/cloudflare/#api-keys) of the Penn Labs Cloudflare account                                              |
 | GF_GH_CLIENT_ID     | The Client ID to the Grafana Penn Labs OAuth2 application on Github                                                                                                               |
 | GF_SLACK_URL        | Slack notification URL used for Grafana notifications                                                                                                                             |
 | GF_GH_CLIENT_SECRET | The Client Secret to the Grafana Penn Labs OAuth2 application on Github                                                                                                           |

--- a/terraform/modules/vault/cert-manager.tf
+++ b/terraform/modules/vault/cert-manager.tf
@@ -1,6 +1,0 @@
-resource "vault_generic_secret" "cloudflare-api-key" {
-  for_each = toset(["sandbox", "production"])
-  path     = "${vault_mount.secrets.path}/${each.key}/cert-manager/cloudflare-api-key-secret"
-
-  data_json = jsonencode({ "api-key" = var.CF_API_KEY })
-}

--- a/terraform/modules/vault/variables.tf
+++ b/terraform/modules/vault/variables.tf
@@ -1,8 +1,3 @@
-variable "CF_API_KEY" {
-  type        = string
-  description = "Global API Key for Penn Labs Cloudflare account"
-}
-
 variable "GF_GH_CLIENT_ID" {
   type        = string
   description = "GitHub Client ID for the Penn Labs Grafana OAuth2 Application"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,3 +22,8 @@ variable "GF_SLACK_URL" {
   type        = string
   description = "Slack notification URL used for Grafana notifications"
 }
+
+variable "DOCKERHUB_TOKEN" {
+  type        = string
+  description = "Read-only API token for Docker Hub"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,8 +1,3 @@
-variable "CF_API_KEY" {
-  type        = string
-  description = "Global API Key for Penn Labs Cloudflare account"
-}
-
 variable "GH_PERSONAL_TOKEN" {
   type        = string
   description = "GitHub Personal Access token for the Penn Labs Admin account"

--- a/terraform/vault.tf
+++ b/terraform/vault.tf
@@ -258,7 +258,6 @@ resource "aws_lb_target_group_attachment" "vault" {
 // Vault configuration
 module "vault" {
   source              = "./modules/vault"
-  CF_API_KEY          = var.CF_API_KEY
   GF_GH_CLIENT_ID     = var.GF_GH_CLIENT_ID
   GF_GH_CLIENT_SECRET = var.GF_GH_CLIENT_SECRET
   GF_SLACK_URL        = var.GF_SLACK_URL


### PR DESCRIPTION
This PR:
* Updates the EKS terraform module (which required us to delete and rebuild the cluster again)
* Creates a docker-pull-secret with a DockerHub token so we don't run into pull limits
* Removes all references to Cloudflare which was previously used by cert-manager (but we've since migrated to route53)
* Does a better job bootstrapping the cluster by running a few `kubectl` commands on cluster creation
* Updates our backend S3 module