### PR TITLE
[Kittyhawk] Fix yarn test: no update snapshot during test

### DIFF
--- a/cdk/kittyhawk/.projen/tasks.json
+++ b/cdk/kittyhawk/.projen/tasks.json
@@ -110,7 +110,7 @@
       "description": "Run tests",
       "steps": [
         {
-          "exec": "jest --passWithNoTests --all --updateSnapshot"
+          "exec": "jest --passWithNoTests --all"
         },
         {
           "spawn": "eslint"

--- a/cdk/kittyhawk/.projenrc.js
+++ b/cdk/kittyhawk/.projenrc.js
@@ -42,5 +42,10 @@ const project = new TypeScriptProject({
 });
 
 project.prettier?.ignoreFile?.addPatterns("src/imports");
+project.testTask.steps.forEach(step => {
+  if (step.exec) {
+    step.exec = step.exec.replace(' --updateSnapshot', '');
+  }
+});
 project.setScript('test', "export GIT_SHA='TESTSHA' AWS_ACCOUNT_ID='TEST_AWS_ACCOUNT_ID' && npx projen test");
 project.synth();


### PR DESCRIPTION
Currently, running `yarn test` for kittyhawk update snapshots, which should not be done. This PR fixes that by:
- Adding in a patch in the `.projenrc.js` file that edits the tasks
- Fixing existing snapshots so that they are up to date