### PR TITLE
[Kraken] Fix npm publish bug: check if version has updated

### DIFF
--- a/cdk/kraken/CHANGELOG.md
+++ b/cdk/kraken/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## X.Y.Z (UNRELEASED)
 
+* Modify CDK stack to only publish when a new version is pushed
+
 ## 0.7.1 (2021-12-16)
 
 * Modify PyPI to correctly publish (again)

--- a/cdk/kraken/src/cdk.ts
+++ b/cdk/kraken/src/cdk.ts
@@ -81,7 +81,7 @@ export class CDKPublishStack extends Stack {
         yarn package
         mv dist/js/*.tgz dist/js/kraken.tgz
         yarn publish --non-interactive --access public dist/js/kraken.tgz`,
-        if: `github.ref == 'refs/heads/${fullConfig.defaultBranch}'`,
+        if: `github.ref == 'refs/heads/${fullConfig.defaultBranch}' && "$(npm info @pennlabs/kittyhawk version)" == "$(node -p "require('./package.json').version")"`,
         env: {
           NPM_AUTH_TOKEN: '${{ secrets.NPM_AUTH_TOKEN }}',
         },

--- a/cdk/kraken/src/cdk.ts
+++ b/cdk/kraken/src/cdk.ts
@@ -75,13 +75,22 @@ export class CDKPublishStack extends Stack {
         yarn run codecov -p $ROOT -F ${id}`,
       },
       {
+        name: 'Check if version is already published to npm',
+        run: dedent`cd ${path}
+        PACKAGE=\$(node -p "require('./package.json').name")
+        VERSION=\$(node -p "require('./package.json').version")
+        NEW_VERSION=\$(yarn info $PACKAGE versions --json | jq -e ".data | any(. == \\"$VERSION\\") | not")
+        echo "::set-output NEW_VERSION=$NEW_VERSION"`,
+      },
+      {
         name: 'Publish to npm',
+        id: 'version_check',
         run: dedent`cd ${path}
         yarn compile
         yarn package
-        mv dist/js/*.tgz dist/js/kraken.tgz
-        yarn publish --non-interactive --access public dist/js/kraken.tgz`,
-        if: `github.ref == 'refs/heads/${fullConfig.defaultBranch}' && "$(npm info @pennlabs/kittyhawk version)" == "$(node -p "require('./package.json').version")"`,
+        mv dist/js/*.tgz dist/js/${id}.tgz
+        yarn publish --non-interactive --access public dist/js/${id}.tgz`,
+        if: `github.ref == 'refs/heads/${fullConfig.defaultBranch}' && steps.version_check.outputs.NEW_VERSION`,
         env: {
           NPM_AUTH_TOKEN: '${{ secrets.NPM_AUTH_TOKEN }}',
         },

--- a/cdk/kraken/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/cdk.test.ts.snap
@@ -38,7 +38,7 @@ jobs:
           yarn package
           mv dist/js/*.tgz dist/js/kraken.tgz
           yarn publish --non-interactive --access public dist/js/kraken.tgz
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && \\"$(npm info @pennlabs/kittyhawk version)\\" == \\"$(node -p \\"require('./package.json').version\\")\\"
         env:
           NPM_AUTH_TOKEN: \${{ secrets.NPM_AUTH_TOKEN }}
       - name: Build docs

--- a/cdk/kraken/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/cdk.test.ts.snap
@@ -36,7 +36,6 @@ jobs:
           cd cdk/example
           PACKAGE=$(node -p \\"require('./package.json').name\\")
           VERSION=$(node -p \\"require('./package.json').version\\")
-          // TODO: check escaping here
           NEW_VERSION=$(yarn info $PACKAGE versions --json | jq -e \\".data | any(. == \\\\\\"$VERSION\\\\\\") | not\\")
           echo \\"::set-output NEW_VERSION=$NEW_VERSION\\"
       - name: Publish to npm

--- a/cdk/kraken/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/cdk.test.ts.snap
@@ -31,14 +31,23 @@ jobs:
           ROOT=$(pwd)
           cd cdk/example
           yarn run codecov -p $ROOT -F example
+      - name: Check if version is already published to npm
+        run: |-
+          cd cdk/example
+          PACKAGE=$(node -p \\"require('./package.json').name\\")
+          VERSION=$(node -p \\"require('./package.json').version\\")
+          // TODO: check escaping here
+          NEW_VERSION=$(yarn info $PACKAGE versions --json | jq -e \\".data | any(. == \\\\\\"$VERSION\\\\\\") | not\\")
+          echo \\"::set-output NEW_VERSION=$NEW_VERSION\\"
       - name: Publish to npm
+        id: version_check
         run: |-
           cd cdk/example
           yarn compile
           yarn package
-          mv dist/js/*.tgz dist/js/kraken.tgz
-          yarn publish --non-interactive --access public dist/js/kraken.tgz
-        if: github.ref == 'refs/heads/master' && \\"$(npm info @pennlabs/kittyhawk version)\\" == \\"$(node -p \\"require('./package.json').version\\")\\"
+          mv dist/js/*.tgz dist/js/example.tgz
+          yarn publish --non-interactive --access public dist/js/example.tgz
+        if: github.ref == 'refs/heads/master' && steps.version_check.outputs.NEW_VERSION
         env:
           NPM_AUTH_TOKEN: \${{ secrets.NPM_AUTH_TOKEN }}
       - name: Build docs


### PR DESCRIPTION
Previously, the "Publish to npm" step does not check if the version in `package.json` has been updated before attempting to publish. 

While this is fixed by the npm erroring out, this behavior should be fixed and the "Publish to npm" step should not run if the version has not changed. 

```
error Couldn't publish package: "https://registry.yarnpkg.com/@pennlabs%2fkittyhawk: You cannot publish over the previously published versions: 1.1.0."
```

This PR adds in an extra check for whether the package version number has been updated compared to the current version number on npm. 

Example generated YAML:
<details>
  <summary>Click to expand!</summary>
  
```yaml
# Generated by cdkactions. Do not modify
# Generated as part of the 'kraken' stack.
name: Publish kraken
on:
  push:
    paths:
      - cdk/kraken/**
jobs:
  publish:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - name: Cache
        uses: actions/cache@v2
        with:
          path: "**/node_modules"
          key: v0-${{ hashFiles('cdk/kraken/yarn.lock') }}
      - name: Install Dependencies
        run: |-
          cd cdk/kraken
          yarn install --frozen-lockfile
      - name: Test
        run: |-
          cd cdk/kraken
          yarn test
      - name: Upload Code Coverage
        run: |-
          ROOT=$(pwd)
          cd cdk/kraken
          yarn run codecov -p $ROOT -F kraken
      - name: Check if version is already published to npm
        run: |-
          cd cdk/kraken
          PACKAGE=$(node -p "require('./package.json').name")
          VERSION=$(node -p "require('./package.json').version")
          NEW_VERSION=$(yarn info $PACKAGE versions --json | jq -e ".data | any(. == \"$VERSION\") | not")
          echo "::set-output NEW_VERSION=$NEW_VERSION"
      - name: Publish to npm
        id: version_check
        run: |-
          cd cdk/kraken
          yarn compile
          yarn package
          mv dist/js/*.tgz dist/js/kraken.tgz
          yarn publish --non-interactive --access public dist/js/kraken.tgz
        if: github.ref == 'refs/heads/master' && steps.version_check.outputs.NEW_VERSION
        env:
          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
      - name: Build docs
        run: |-
          cd cdk/kraken
          yarn docgen
      - name: Publish docs
        if: github.ref == 'refs/heads/master'
        uses: peaceiris/actions-gh-pages@v3
        with:
          personal_token: ${{ secrets.BOT_GITHUB_PAT }}
          external_repository: pennlabs/kraken-docs
          cname: kraken.pennlabs.org
          publish_branch: master
          publish_dir: cdk/kraken/docs
          user_name: github-actions
          user_email: github-actions[bot]@users.noreply.github.com
    container:
      image: node:14
```
</details>