### PR TITLE
[Terraform] Remove desired_size config, scale up k8s_cluster_size local

### DIFF
--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -9,8 +9,8 @@ module "eks-production" {
   vpc_id          = module.vpc.vpc_id
   eks_managed_node_groups = {
     spot = {
-      max_size     = local.k8s_cluster_size
-      min_size     = local.k8s_cluster_size
+      max_size = local.k8s_cluster_size
+      min_size = local.k8s_cluster_size
 
       create_launch_template = false
       launch_template_name   = ""

--- a/terraform/eks.tf
+++ b/terraform/eks.tf
@@ -9,7 +9,6 @@ module "eks-production" {
   vpc_id          = module.vpc.vpc_id
   eks_managed_node_groups = {
     spot = {
-      desired_size = local.k8s_cluster_size
       max_size     = local.k8s_cluster_size
       min_size     = local.k8s_cluster_size
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,7 +42,7 @@ locals {
     "jonathan",
   ])
   k8s_cluster_name = "production"
-  k8s_cluster_size = 3
+  k8s_cluster_size = 5
   vault_ami        = "ami-0eec2c28d4dd94628"
   domains = toset([
     "ohq.io",


### PR DESCRIPTION
This PR scales up the number of nodes (and adds the number of replicas for traefik).

**Wait, aren't we already at 5 nodes?**
Currently, we already scaled up to 5 nodes in AWS via console. However, when we tf apply again, the number of nodes would go back to 3 nodes (I don't know if it _actually_ becomes 3 nodes, but the min/max all get moved back from 2/5 to 3/3). This is pretty sus behavior.

Originally, I planned to delete the `k8s_cluster_size local` because the [desired_size is unsupported](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/faq.md#why-are-there-no-changes-when-a-node-groups-desired_size-is-modified). However, the local is still used for the `min_size` & `max_size`, as well as the replicas field for traefik. 

**Alternative solution:** maybe can remove the `k8s_cluster_size` local as a whole, remove `min_size` and `max_size`, and then set an arbitrary value for the number of replicas in traefik.

**TODO**
- [x] tf plan and check that things make sense
- [x] tf apply locally