### PR TITLE
Allow `integrationTests` to be a string

### DIFF
--- a/cdk/kraken/src/docker.ts
+++ b/cdk/kraken/src/docker.ts
@@ -53,11 +53,11 @@ export interface DockerPublishJobProps {
   cache?: boolean;
 
   /**
-   * If enabled, do not publish docker image to Docker Hub.
+   * If evaluates to true, do not publish docker image to Docker Hub.
    * Instead upload as an artifact.
    * @default false
    */
-  noPublish?: boolean;
+  noPublish?: boolean | string;
 }
 
 /**

--- a/cdk/kraken/src/labs-application.ts
+++ b/cdk/kraken/src/labs-application.ts
@@ -28,10 +28,10 @@ export interface LabsApplicationStackProps {
   frontendPath?: string;
 
   /**
-   * If true, run integration tests using docker-compose.
+   * If evaluates to true, run integration tests using docker-compose.
    * @default false
    */
-  integrationTests?: boolean;
+  integrationTests?: boolean | string;
 
   /**
    * Base name of the docker images to publish.


### PR DESCRIPTION
Allow `integrationTests` to be a string to enable passing in a commit message flag which would (hopefully) compile down to a boolean.

The idea is to use something like this `"!contains(github.event.head_commit.message, '[skip int]')"` as the argument to `integrationTests` in individual app config

