### PR TITLE
Shorten AWS RDS Timeouts

### DIFF
--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -40,6 +40,7 @@ resource "aws_db_instance" "production" {
   engine_version                      = "11.13"
   availability_zone                   = "us-east-1a"
   allocated_storage                   = 20
+  max_allocated_storage               = 100
   username                            = "postgres"
   password                            = random_password.rds-password.result
   iam_database_authentication_enabled = true
@@ -49,6 +50,11 @@ resource "aws_db_instance" "production" {
   tags = {
     Name       = "Production",
     created-by = "terraform"
+  }
+  timeouts {
+    create = "2m"
+    update = "4m"
+    delete = "3m"
   }
 }
 


### PR DESCRIPTION
Previously, to handle the Clubs outage, we ran a cronjob in the background to kill-off any hanging queries > 60s. To prevent such measures in the future, we will shorten the timeout limits for AWS RDS:

Original (Default Values)
- create - (Default 40m)
- update - (Default 80m) 
- delete - (Default 60m)

New Values
- create - (2m)
- update - (4m) 
- delete - (3m)