### PR TITLE
Bump shibboleth-sp-nginx to Debian 12 (again)

### DIFF
--- a/docker/shibboleth-sp-nginx/Dockerfile
+++ b/docker/shibboleth-sp-nginx/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim AS build
 
 # Install dependencies
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y gnupg2 ca-certificates wget git mercurial build-essential lsb-release devscripts fakeroot quilt libssl-dev libpcre2-dev libpcre3-dev zlib1g-dev debhelper libxml2-utils xsltproc \
+    && apt-get install --no-install-recommends -y gnupg2 ca-certificates wget git mercurial build-essential lsb-release devscripts fakeroot quilt libssl-dev libpcre2-dev libpcre3-dev zlib1g-dev debhelper libxml2-utils xsltproc libparse-recdescent-perl \
     && rm -rf /var/lib/apt/lists/*
 
 # Add Nginx repository and install
@@ -39,6 +39,7 @@ RUN wget -qO - https://nginx.org/keys/nginx_signing.key | apt-key add - \
 
 # Install Shibboleth, Nginx, and Supervisor
 RUN apt-get update && apt-get install --no-install-recommends -y libapache2-mod-shib supervisor nginx \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Nginx modules

--- a/docker/shibboleth-sp-nginx/Dockerfile
+++ b/docker/shibboleth-sp-nginx/Dockerfile
@@ -1,17 +1,15 @@
 # Build stage
-FROM debian:buster-slim AS build
-
-ENV NGINX_VERSION=1.18.0-2~buster
+FROM debian:bookworm-slim AS build
 
 # Install dependencies
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y gnupg2 ca-certificates wget git mercurial build-essential lsb-release devscripts fakeroot quilt libssl-dev libpcre3-dev zlib1g-dev debhelper libxml2-utils xsltproc \
+    && apt-get install --no-install-recommends -y gnupg2 ca-certificates wget git mercurial build-essential lsb-release devscripts fakeroot quilt libssl-dev libpcre2-dev libpcre3-dev zlib1g-dev debhelper libxml2-utils xsltproc \
     && rm -rf /var/lib/apt/lists/*
 
 # Add Nginx repository and install
 RUN wget -qO - https://nginx.org/keys/nginx_signing.key | apt-key add - \
-    && echo "deb http://nginx.org/packages/debian/ buster nginx" > /etc/apt/sources.list.d/nginx.list \
-    && apt-get update && apt-get install --no-install-recommends -y nginx=$NGINX_VERSION \
+    && echo "deb http://nginx.org/packages/debian/ bookworm nginx" > /etc/apt/sources.list.d/nginx.list \
+    && apt-get update && apt-get install --no-install-recommends -y nginx \
     && rm -rf /var/lib/apt/lists/*
 
 # Install pkg-oss
@@ -26,25 +24,21 @@ RUN pkg-oss/build_module.sh --skip-depends -y -o /root/nginx-modules/deb/ -n shi
     && rm -f /root/nginx-modules/deb/*-dbg_*.deb
 
 # Production stage
-FROM debian:buster-slim
+FROM debian:bookworm-slim
 
 LABEL maintainer="Penn Labs"
-
-ENV NGINX_VERSION=1.18.0-2~buster
 
 # Install dependencies
 RUN apt-get update \
     && apt-get install --no-install-recommends -y gnupg2 wget ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-# Add Shibboleth and Nginx repositories
-RUN wget -qO - http://pkg.switch.ch/switchaai/SWITCHaai-swdistrib.asc | apt-key add - \
-    && wget -qO - https://nginx.org/keys/nginx_signing.key | apt-key add - \
-    && echo "deb http://pkg.switch.ch/switchaai/debian/ buster main" > /etc/apt/sources.list.d/switch-shibboleth.list \
-    && echo "deb http://nginx.org/packages/debian/ buster nginx" > /etc/apt/sources.list.d/nginx.list
+# Add Nginx repository
+RUN wget -qO - https://nginx.org/keys/nginx_signing.key | apt-key add - \
+    && echo "deb http://nginx.org/packages/debian/ bookworm nginx" > /etc/apt/sources.list.d/nginx.list
 
 # Install Shibboleth, Nginx, and Supervisor
-RUN apt-get update && apt-get install --no-install-recommends -y shibboleth=3.0.4+switchaai2~buster1 supervisor nginx=$NGINX_VERSION \
+RUN apt-get update && apt-get install --no-install-recommends -y libapache2-mod-shib supervisor nginx \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Nginx modules


### PR DESCRIPTION
Second time is the charm... this PR fixes nondeterminism that caused the shibboleth-sp-nginx build to fail, but ONLY the first time you build it (future builds succeeded due to caching or something, which is why I didn't catch this locally the first time).