### PR TITLE
Disable Redis Protected Mode

### DIFF
--- a/terraform/modules/base_cluster/redis.tf
+++ b/terraform/modules/base_cluster/redis.tf
@@ -8,6 +8,7 @@ resource "kubernetes_config_map" "redis_config_map" {
     save 3600 30
     dir /redis-master-data/
     dbfilename dump.rdb
+    protected-mode no
     EOF
   }
 }


### PR DESCRIPTION
Courses backend was having issues with redis connectivity, turns out that redis base image has protected mode enabled by default. Fixed redis config map to disable protected mode!