### PR TITLE
Waypoint: Print more descriptive error message when Docker isn't running

### DIFF
--- a/docker/waypoint/src/waypoint_client.py
+++ b/docker/waypoint/src/waypoint_client.py
@@ -106,13 +106,17 @@ def start(rebuild: bool = False) -> None:
     env["WAYPOINT_CODE_DIR"] = config["code_dir"]
     env["WAYPOINT_SECRETS_DIR"] = config["secrets_dir"]
 
-    result = subprocess.run(
-        ["docker", "images", "-q", IMAGE_NAME],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    image_found = result.stdout.strip()
+    try:
+        waypoint_image = subprocess.run(
+            ["docker", "images", "-q", IMAGE_NAME],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        image_found = waypoint_image.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to check Docker images for {IMAGE_NAME}: {e.stderr or e}")
+        sys.exit(1)
 
     if not image_found or rebuild:
         if not image_found:


### PR DESCRIPTION
`waypoint-client start` checks to see if the waypoint image is available locally, which fails if the docker daemon is not running. However, this is not very clear from the error output:
```bash
waypoint-client start
Traceback (most recent call last):
  File "src/waypoint_client.py", line 254, in <module>
  File "src/waypoint_client.py", line 245, in main
  File "src/waypoint_client.py", line 108, in start
  File "subprocess.py", line 571, in run
subprocess.CalledProcessError: Command '['docker', 'images', '-q', 'pennlabs/waypoint']' returned non-zero exit status 1.
[PYI-69035:ERROR] Failed to execute script 'waypoint_client' due to unhandled exception!
```

This PR includes the error output of the `docker images` command, which could provide a hint to the user as to why the command is failing. New output:

Failed to check Docker images for pennlabs/waypoint: Cannot connect to the Docker daemon at unix:///Users/christopherliu/.orbstack/run/docker.sock. Is the docker daemon running?