### PR TITLE
Waypoint: Don't push to dockerhub unless on master

### DIFF
--- a/.github/workflows/cdkactions_docker-waypoint.yaml
+++ b/.github/workflows/cdkactions_docker-waypoint.yaml
@@ -22,12 +22,29 @@ jobs:
         with:
           path: /tmp/.buildx-cache
           key: buildx-publish-waypoint
+      # Only log in to Docker Hub if pushing to master
       - uses: docker/login-action@v1
+        if: github.ref == 'refs/heads/master'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      # Build the Docker image but don't push if not on master
+      - name: Build/Publish (Dry Run)
+        uses: docker/build-push-action@v6
+        if: github.ref != 'refs/heads/master'
+        with:
+          context: docker/waypoint
+          file: docker/waypoint/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          cache-from: type=local,src=/tmp/.buildx-cache,type=registry,ref=pennlabs/waypoint:latest
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          tags: |
+            pennlabs/waypoint:latest
+            pennlabs/waypoint:${{ github.sha }}
       - name: Build/Publish
         uses: docker/build-push-action@v6
+        if: github.ref == 'refs/heads/master'
         with:
           context: docker/waypoint
           file: docker/waypoint/Dockerfile


### PR DESCRIPTION
PRs for Waypoint result in actual changes to pennlabs/waypoint:latest on Docker Hub because the current GH actions don't check to see if we're pushing to master. This PR will build and cache the Docker image but will only actually push to Docker Hub if we're on master.