### PR TITLE
Waypoint: Add WaypointStatus enum

### DIFF
--- a/docker/waypoint/src/waypoint_client.py
+++ b/docker/waypoint/src/waypoint_client.py
@@ -4,11 +4,13 @@ import subprocess
 import sys
 import argparse
 import json
+from enum import Enum
 
 
 CONFIG_FILE = os.path.expanduser("~/.waypoint/config.json")
 IMAGE_NAME = "pennlabs/waypoint"
 CONTAINER_NAME = "waypoint-1"
+
 
 def load_config() -> dict:
     """Load waypoint configuration from file."""
@@ -115,34 +117,38 @@ def start(rebuild: bool = False) -> None:
 
     if not image_found or rebuild:
         if not image_found:
-            print(f"Docker image {IMAGE_NAME} not found. Pulling from pennlabs/waypoint...")
+            print(
+                f"Docker image {IMAGE_NAME} not found. Pulling from pennlabs/waypoint..."
+            )
         else:
-            print(f"--rebuild flag detected. Pulling latest pennlabs/waypoint...")
+            print("--rebuild flag detected. Pulling latest pennlabs/waypoint...")
         try:
             subprocess.run(["docker", "pull", IMAGE_NAME], check=True)
         except subprocess.CalledProcessError:
             print("\nError: Failed to pull waypoint container")
             sys.exit(1)
 
-    ssh_dir = os.path.join(config['config_dir'], '.ssh')
-    gnupg_dir = os.path.join(config['config_dir'], '.gnupg')
+    ssh_dir = os.path.join(config["config_dir"], ".ssh")
+    gnupg_dir = os.path.join(config["config_dir"], ".gnupg")
 
     # Check if the ssh and gnupg directories exist, and create them if they don't
     if not os.path.exists(ssh_dir):
         os.makedirs(ssh_dir)
     if not os.path.exists(gnupg_dir):
         os.makedirs(gnupg_dir)
-    
+
     waypoint_state = is_waypoint_running()
-    if waypoint_state == 2: 
-            print(f"Waypoint is already running. Use 'waypoint-client spawn' to open a new shell.")
+    if waypoint_state == WaypointStatus.RUNNING:
+        print(
+            "Waypoint is already running. Use 'waypoint-client spawn' to open a new shell."
+        )
+        sys.exit(1)
+    elif waypoint_state == WaypointStatus.NOT_RUNNING:
+        try:
+            subprocess.run(["docker", "start", "-ai", CONTAINER_NAME], check=True)
+        except subprocess.CalledProcessError:
+            print("\nError: Failed to start waypoint container")
             sys.exit(1)
-    elif waypoint_state == 1:
-            try:
-                subprocess.run(["docker", "start", "-ai", CONTAINER_NAME], check=True)
-            except subprocess.CalledProcessError:
-                print("\nError: Failed to start waypoint container")
-                sys.exit(1)
     else:
         try:
             try:
@@ -166,7 +172,7 @@ def start(rebuild: bool = False) -> None:
                         "--name",
                         CONTAINER_NAME,
                         IMAGE_NAME,
-                        "bash"
+                        "bash",
                     ],
                     check=True,
                 )
@@ -181,35 +187,43 @@ def start(rebuild: bool = False) -> None:
             print("\nStartup interrupted.")
             sys.exit(1)
 
-def is_waypoint_running() -> int:
-    """Check the state of the waypoint container. 
-    Returns 0 if the container does not exist, 
-    1 if the container exists but is not running, and 2 if the container is running."""
+
+class WaypointStatus(Enum):
+    DOES_NOT_EXIST = 0  # container does not exist
+    NOT_RUNNING = 1  # container is not running but does exist
+    RUNNING = 2  # container is running
+
+
+def is_waypoint_running() -> WaypointStatus:
+    """Check the state of the waypoint container."""
     result = subprocess.run(
         ["docker", "inspect", "--format", "{{.State.Running}}", CONTAINER_NAME],
-        capture_output=True, text=True, check=False
+        capture_output=True,
+        text=True,
+        check=False,
     )
-    
+
     if result.returncode != 0:
         # Container does not exist
-        return 0
-    
+        return WaypointStatus.DOES_NOT_EXIST
+
     if result.stdout.strip() == "true":
         # Container is running
-        return 2
-    
+        return WaypointStatus.RUNNING
+
     # Container exists but is not running
-    return 1
+    return WaypointStatus.NOT_RUNNING
 
 
 def spawn() -> None:
     """Spawn a new bash shell in the waypoint container."""
-    if is_waypoint_running() == 2:
+    if is_waypoint_running() == WaypointStatus.RUNNING:
         print("Waypoint contianer found, spawning new bash shell...")
         subprocess.run(["docker", "exec", "-it", CONTAINER_NAME, "bash"], check=False)
     else:
         print("Error: Waypoint container not found, is it running?")
         sys.exit(1)
+
 
 def main() -> None:
     """Main entry point for waypoint client."""
@@ -224,7 +238,9 @@ def main() -> None:
         help="Rebuild waypoint image to be up to date. Note this will delete the existing image and start from scratch, but your code and secrets will be preserved.",
     )
 
-    subparsers.add_parser("spawn", help="Spawn a new bash shell in the waypoint container")
+    subparsers.add_parser(
+        "spawn", help="Spawn a new bash shell in the waypoint container"
+    )
 
     args = parser.parse_args()
 


### PR DESCRIPTION
Change the return type of `is_waypoint_running()` to an enum instead of using raw ints to represent the waypoint container status. This status is already represented as an enum (0, 1, 2) but we don't enforce this using the type system and the representations themselves don't give any hints about their meaning other than having comments that remind devs what the ints are supposed to represent.