### PR TITLE
Use uv only for waypoint backend installation

### DIFF
--- a/docker/waypoint/Dockerfile
+++ b/docker/waypoint/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y locales
 RUN locale-gen en_US.UTF-8
 RUN update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
-RUN pip3 install uv pipenv
+RUN pip3 install uv 
 
 # --- labs setup
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tzdata \

--- a/docker/waypoint/Dockerfile
+++ b/docker/waypoint/Dockerfile
@@ -20,21 +20,21 @@ RUN pip3 install uv pipenv
 
 # --- labs setup
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y tzdata \
-    && ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime \
-    && dpkg-reconfigure -f noninteractive tzdata
+  && ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime \
+  && dpkg-reconfigure -f noninteractive tzdata
 
 RUN apt-get update && apt-get install -y postgresql postgresql-contrib redis-server systemd
 
 # Install nvm, node, and npm, yarn
 ENV NVM_DIR=/usr/local/nvm
-ENV NODE_VERSION=20
+ENV NODE_VERSION=22
 
 RUN mkdir -p $NVM_DIR && \
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash && \
-    . $NVM_DIR/nvm.sh && \
-    nvm install $NODE_VERSION && \
-    nvm alias default $NODE_VERSION && \
-    nvm use default
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash && \
+  . $NVM_DIR/nvm.sh && \
+  nvm install $NODE_VERSION && \
+  nvm alias default $NODE_VERSION && \
+  nvm use default
 
 RUN . $NVM_DIR/nvm.sh && npm install -g yarn
 

--- a/docker/waypoint/src/main.py
+++ b/docker/waypoint/src/main.py
@@ -4,23 +4,7 @@ import os
 import subprocess
 import sys
 
-PRODUCTS = {
-    "office-hours-queue": {
-        "node_version": "22",
-    },
-    "penn-clubs": {
-        "node_version": "20",
-    },
-    "penn-mobile": {
-        "node_version": "22",
-    },
-    "penn-courses": {
-        "node_version": "22",
-    },
-    "platform": {
-        "node_version": "22",
-    },
-}
+PRODUCTS = ["office-hours-queue", "penn-clubs", "penn-mobile", "penn-courses", "platform"]
 
 WAYPOINT_DIR = "/opt/waypoint"
 CODE_DIR = "/labs"
@@ -52,7 +36,7 @@ def clone_and_init_product(product: str) -> None:
 
     if product not in PRODUCTS:
         print(f"Error: Unknown product '{product}'")
-        print(f"Available products: {', '.join(PRODUCTS.keys())}")
+        print(f"Available products: {', '.join(PRODUCTS)}")
         sys.exit(1)
 
     clone_product(product)
@@ -163,7 +147,7 @@ def sync_env(product: str) -> None:
     """Sync .env file from product to waypoint."""
     if product not in PRODUCTS:
         print(f"Error: Unknown product '{product}'")
-        print(f"Available products: {', '.join(PRODUCTS.keys())}")
+        print(f"Available products: {', '.join(PRODUCTS)}")
         sys.exit(1)
 
     product_backend_path = os.path.join(CODE_DIR, product, "backend")
@@ -205,7 +189,7 @@ def switch_product(product: str, no_vsc: bool) -> None:
     """Switch to a different product environment"""
     if product not in PRODUCTS:
         print(f"Error: Unknown product '{product}'")
-        print(f"Available products: {', '.join(PRODUCTS.keys())}")
+        print(f"Available products: {', '.join(PRODUCTS)}")
         sys.exit(1)
 
     product_path = os.path.join(WAYPOINT_DIR, product)
@@ -312,7 +296,7 @@ def main() -> None:
     )
     init_parser.add_argument(
         "product",
-        help="Product to initalize to, options: " + ", ".join(PRODUCTS.keys()),
+        help="Product to initalize to, options: " + ", ".join(PRODUCTS),
         nargs="?",
         default=None,
     )
@@ -322,7 +306,7 @@ def main() -> None:
         help="Switch to a product environment. Starts the uv virtual environment associated with the product and opens the product in VSCode if in a dev container. Use --no-vsc to not open VSCode.",
     )
     switch_parser.add_argument(
-        "product", help="Product to switch to, options: " + ", ".join(PRODUCTS.keys())
+        "product", help="Product to switch to, options: " + ", ".join(PRODUCTS)
     )
     switch_parser.add_argument("--no-vsc", action="store_true", help="Do not open VSCode on switch")
 

--- a/docker/waypoint/src/main.py
+++ b/docker/waypoint/src/main.py
@@ -67,14 +67,14 @@ def clone_and_init_product(product: str) -> None:
     # Run manage.py commands
     try:
         subprocess.run(
-            f"bash -c 'cd {backend_path} && uv run python manage.py migrate'",
+            f"bash -c 'cd {backend_path} && uv run manage.py migrate'",
             shell=True,
             check=True,
         )
 
         if product not in ["penn-mobile", "penn-courses", "platform"]:
             subprocess.run(
-                f"bash -c 'cd {backend_path} && python manage.py populate'",
+                f"bash -c 'cd {backend_path} && uv run manage.py populate'",
                 shell=True,
                 check=True,
             )

--- a/docker/waypoint/waypoint-bashrc
+++ b/docker/waypoint/waypoint-bashrc
@@ -4,7 +4,7 @@ waypoint-switch-shell-context() {
         PRODUCT_NAME=$(basename "$symlink_path")
 
         cd "/labs/$PRODUCT_NAME"
-        source "/opt/waypoint/$PRODUCT_NAME/venv/bin/activate"
+        source "/opt/waypoint/$PRODUCT_NAME/.venv/bin/activate"
     else
         echo 'Run "waypoint switch <product>" to jump into a product environment.'
     fi

--- a/docker/waypoint/waypoint-init
+++ b/docker/waypoint/waypoint-init
@@ -1,14 +1,18 @@
 #!/bin/bash
 
 declare -A PRODUCT_TO_SHA
+declare -A PRODUCT_TO_SHA_LEGACY
 declare -A PRODUCT_TO_NODE_VERSION
 
 PRODUCT_TO_SHA=(
-  ["office-hours-queue"]="524282d029a330b59158e80299e3be23988f1765"
-  ["penn-clubs"]="1bcd3ce4f3040395e081989df81fd3105047b24b"
-  ["penn-mobile"]="f0a65d07764f4e3bce56b3f5349c0b556d708780"
-  ["penn-courses"]="01e3dac5f5465ad39f810b2c81969f0165c70dcf"
-  ["platform"]="42c56ff509f60de5389262a9de5e38faf1d9aac2"
+  ["office-hours-queue"]="7fdcdaeba0b83600950edfbdfb155ba62cd2febd"
+  ["penn-clubs"]="a69532b40c40c6ad0a2c6856e11034c70fbab26c"
+)
+
+PRODUCT_TO_SHA_LEGACY=(
+  ["penn-mobile"]="093a9f58ec7d778acc12dad40d0ece109e6346e8"
+  ["penn-courses"]="e787256c332741db357baf3d005b20158d7b35c7"
+  ["platform"]="022d2671a7811e8e2b6f772948ff28d18fa6422a"
 )
 
 PRODUCT_TO_NODE_VERSION=(
@@ -19,19 +23,39 @@ PRODUCT_TO_NODE_VERSION=(
   ["platform"]="22"
 )
 
-
+# uv native installation using [uv sync]
 for product in "${!PRODUCT_TO_SHA[@]}"; do
-  echo "Installing dependencies for $product"
   sha="${PRODUCT_TO_SHA[$product]}"
   PRODUCT_PATH="/opt/waypoint/$product"
+  BACKEND_BASE="https://raw.githubusercontent.com/pennlabs/$product/$sha/backend"
+
+  echo "Installing dependencies for $product @ $sha with uv"
   mkdir -p "$PRODUCT_PATH"
 
-  curl -o $PRODUCT_PATH/Pipfile "https://raw.githubusercontent.com/pennlabs/$product/$sha/backend/Pipfile"
-  curl -o $PRODUCT_PATH/Pipfile.lock "https://raw.githubusercontent.com/pennlabs/$product/$sha/backend/Pipfile.lock"
+  uv venv "$PRODUCT_PATH/venv" --python 3.11 --prompt "$product" 
+  curl -o $PRODUCT_PATH/pyproject.toml "$BACKEND_BASE/pyproject.toml"
+  curl -o $PRODUCT_PATH/uv.lock "$BACKEND_BASE/uv.lock"
+
+  cd $PRODUCT_PATH
+  source "$PRODUCT_PATH/venv/bin/activate" && uv sync --frozen --all-groups
+done
+
+# Legacy installation using Pipfile: use pipenv to convert Pipfile to requirements.txt and use
+# [uv pip install -r] to install to uv
+for product in "${!PRODUCT_TO_SHA_PIPENV[@]}"; do
+  sha="${PRODUCT_TO_SHA_PIPENV[$product]}"
+  PRODUCT_PATH="/opt/waypoint/$product"
+  BACKEND_BASE="https://raw.githubusercontent.com/pennlabs/$product/$sha/backend"
+
+  echo "Installing dependencies for $product @ $sha with Pipfile"
+  mkdir -p "$PRODUCT_PATH"
 
   uv venv "$PRODUCT_PATH/venv" --python 3.11 --prompt "$product" 
+  curl -o $PRODUCT_PATH/Pipfile "$BACKEND_BASE/Pipfile"
+  curl -o $PRODUCT_PATH/Pipfile.lock "$BACKEND_BASE/Pipfile.lock"
+
   cd $PRODUCT_PATH
-  source "$PRODUCT_PATH/venv/bin/activate" && pipenv requirements --dev > requirements.txt && uv pip install -r $PRODUCT_PATH/requirements.txt
+  source "$PRODUCT_PATH/venv/bin/activate" && pipenv requirements --dev > "$PRODUCT_PATH/requirements.txt" && uv pip install -r "$PRODUCT_PATH/requirements.txt"
 done
 
 echo "Setup complete!"

--- a/docker/waypoint/waypoint-init
+++ b/docker/waypoint/waypoint-init
@@ -1,18 +1,15 @@
 #!/bin/bash
 
 declare -A PRODUCT_TO_SHA
-declare -A PRODUCT_TO_SHA_LEGACY
 declare -A PRODUCT_TO_NODE_VERSION
 
+# TODO: Add remaining products back since they aren't migrated to uv
 PRODUCT_TO_SHA=(
   ["office-hours-queue"]="7fdcdaeba0b83600950edfbdfb155ba62cd2febd"
   ["penn-clubs"]="a69532b40c40c6ad0a2c6856e11034c70fbab26c"
-)
-
-PRODUCT_TO_SHA_LEGACY=(
-  ["penn-mobile"]="093a9f58ec7d778acc12dad40d0ece109e6346e8"
-  ["penn-courses"]="e787256c332741db357baf3d005b20158d7b35c7"
-  ["platform"]="022d2671a7811e8e2b6f772948ff28d18fa6422a"
+  # ["penn-mobile"]="093a9f58ec7d778acc12dad40d0ece109e6346e8"
+  # ["penn-courses"]="e787256c332741db357baf3d005b20158d7b35c7"
+  # ["platform"]="022d2671a7811e8e2b6f772948ff28d18fa6422a"
 )
 
 PRODUCT_TO_NODE_VERSION=(
@@ -32,30 +29,11 @@ for product in "${!PRODUCT_TO_SHA[@]}"; do
   echo "Installing dependencies for $product @ $sha with uv"
   mkdir -p "$PRODUCT_PATH"
 
-  uv venv "$PRODUCT_PATH/venv" --python 3.11 --prompt "$product" 
   curl -o $PRODUCT_PATH/pyproject.toml "$BACKEND_BASE/pyproject.toml"
   curl -o $PRODUCT_PATH/uv.lock "$BACKEND_BASE/uv.lock"
 
   cd $PRODUCT_PATH
-  source "$PRODUCT_PATH/venv/bin/activate" && uv sync --frozen --all-groups
-done
-
-# Legacy installation using Pipfile: use pipenv to convert Pipfile to requirements.txt and use
-# [uv pip install -r] to install to uv
-for product in "${!PRODUCT_TO_SHA_PIPENV[@]}"; do
-  sha="${PRODUCT_TO_SHA_PIPENV[$product]}"
-  PRODUCT_PATH="/opt/waypoint/$product"
-  BACKEND_BASE="https://raw.githubusercontent.com/pennlabs/$product/$sha/backend"
-
-  echo "Installing dependencies for $product @ $sha with Pipfile"
-  mkdir -p "$PRODUCT_PATH"
-
-  uv venv "$PRODUCT_PATH/venv" --python 3.11 --prompt "$product" 
-  curl -o $PRODUCT_PATH/Pipfile "$BACKEND_BASE/Pipfile"
-  curl -o $PRODUCT_PATH/Pipfile.lock "$BACKEND_BASE/Pipfile.lock"
-
-  cd $PRODUCT_PATH
-  source "$PRODUCT_PATH/venv/bin/activate" && pipenv requirements --dev > "$PRODUCT_PATH/requirements.txt" && uv pip install -r "$PRODUCT_PATH/requirements.txt"
+  uv sync --frozen --all-groups
 done
 
 echo "Setup complete!"

--- a/docker/waypoint/waypoint-init
+++ b/docker/waypoint/waypoint-init
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 declare -A PRODUCT_TO_SHA
-declare -A PRODUCT_TO_NODE_VERSION
 
 # TODO: Add remaining products back since they aren't migrated to uv
 PRODUCT_TO_SHA=(
@@ -10,14 +9,6 @@ PRODUCT_TO_SHA=(
   # ["penn-mobile"]="093a9f58ec7d778acc12dad40d0ece109e6346e8"
   # ["penn-courses"]="e787256c332741db357baf3d005b20158d7b35c7"
   # ["platform"]="022d2671a7811e8e2b6f772948ff28d18fa6422a"
-)
-
-PRODUCT_TO_NODE_VERSION=(
-  ["office-hours-queue"]="22"
-  ["penn-clubs"]="20"
-  ["penn-mobile"]="22"
-  ["penn-courses"]="22"
-  ["platform"]="22"
 )
 
 # uv native installation using [uv sync]


### PR DESCRIPTION
Use `pyproject.toml` and `uv.lock` to install backend dependencies with uv. Previously, we had a hacky workaround where we generated a requirements.txt from a Pipfile and then used uv's legacy commands.

The products that haven't been fully migrated to uv are currently commented out (courses, mobile, platform as of now). We should ensure that they are fully migrated within the next week.