### PR TITLE
Bump version to v1.0.4

### DIFF
--- a/docker/waypoint/install.sh
+++ b/docker/waypoint/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 INSTALL_DIR="/usr/local/bin"
-WAYPOINT_VERSION="v1.0.3"
+WAYPOINT_VERSION="v1.0.4"
 GITHUB_ORG="pennlabs"
 REPO_NAME="infrastructure"
 

--- a/docker/waypoint/setup.py
+++ b/docker/waypoint/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="waypoint",
-    version="1.0.3",
+    version="1.0.4",
     package_dir={"": "src"},
     py_modules=["main", "waypoint_client"],
     install_requires=[],


### PR DESCRIPTION
We should wait to merge this until all products are using uv and we're able to bump the hashes. (Might require us to create v1.0.4.1?)