### PR TITLE
Bump debian version from buster to bookworm

### DIFF
--- a/.github/cdk/main.ts
+++ b/.github/cdk/main.ts
@@ -44,7 +44,7 @@ new CDKPublishStack(app, "kittyhawk")
 const dockerImages = ["datadog-agent", "pg-s3-backup", "team-sync"]
 dockerImages.map((name) => new DockerPublishStack(app, name))
 new DjangoBaseDockerStack(app, {
-	pythonVersions: ["3.9.14", "3.8.5", "3.10.1", "3.11"],
+	pythonVersions: ["3.9.23", "3.10.18", "3.11"],
 })
 new ShibbolethDockerStack(app)
 

--- a/.github/cdk/main.ts
+++ b/.github/cdk/main.ts
@@ -44,7 +44,7 @@ new CDKPublishStack(app, "kittyhawk")
 const dockerImages = ["datadog-agent", "pg-s3-backup", "team-sync"]
 dockerImages.map((name) => new DockerPublishStack(app, name))
 new DjangoBaseDockerStack(app, {
-	pythonVersions: ["3.9.23", "3.10.18", "3.11"],
+	pythonVersions: ["3.10.18", "3.11"],
 })
 new ShibbolethDockerStack(app)
 

--- a/.github/workflows/cdkactions_docker-django-base.yaml
+++ b/.github/workflows/cdkactions_docker-django-base.yaml
@@ -6,32 +6,6 @@ on:
     paths:
       - docker/django-base/**
 jobs:
-  publish-django-base-3-9-23:
-    name: Publish django-base-3-9-23
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-publish-django-base-3-9-23
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build/Publish
-        uses: docker/build-push-action@v6
-        with:
-          context: docker/django-base
-          file: docker/django-base/Dockerfile
-          push: ${{ github.ref == 'refs/heads/master' }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: PYTHON_VERSION=3.9.23
-          tags: pennlabs/django-base:${{ github.sha }}-3.9.23
   publish-django-base-3-10-18:
     name: Publish django-base-3-10-18
     runs-on: ubuntu-latest

--- a/.github/workflows/cdkactions_docker-django-base.yaml
+++ b/.github/workflows/cdkactions_docker-django-base.yaml
@@ -6,8 +6,8 @@ on:
     paths:
       - docker/django-base/**
 jobs:
-  publish-django-base-3-9-14:
-    name: Publish django-base-3-9-14
+  publish-django-base-3-9-23:
+    name: Publish django-base-3-9-23
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,7 +17,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: buildx-publish-django-base-3-9-14
+          key: buildx-publish-django-base-3-9-23
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -30,10 +30,10 @@ jobs:
           push: ${{ github.ref == 'refs/heads/master' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: PYTHON_VERSION=3.9.14
-          tags: pennlabs/django-base:${{ github.sha }}-3.9.14
-  publish-django-base-3-8-5:
-    name: Publish django-base-3-8-5
+          build-args: PYTHON_VERSION=3.9.23
+          tags: pennlabs/django-base:${{ github.sha }}-3.9.23
+  publish-django-base-3-10-18:
+    name: Publish django-base-3-10-18
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,33 +43,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
-          key: buildx-publish-django-base-3-8-5
-      - uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build/Publish
-        uses: docker/build-push-action@v6
-        with:
-          context: docker/django-base
-          file: docker/django-base/Dockerfile
-          push: ${{ github.ref == 'refs/heads/master' }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: PYTHON_VERSION=3.8.5
-          tags: pennlabs/django-base:${{ github.sha }}-3.8.5
-  publish-django-base-3-10-1:
-    name: Publish django-base-3-10-1
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-publish-django-base-3-10-1
+          key: buildx-publish-django-base-3-10-18
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -83,7 +57,7 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           build-args: PYTHON_VERSION=3.10.1
-          tags: pennlabs/django-base:${{ github.sha }}-3.10.1
+          tags: pennlabs/django-base:${{ github.sha }}-3.10.18
   publish-django-base-3-11:
     name: Publish django-base-3-11
     runs-on: ubuntu-latest

--- a/.github/workflows/cdkactions_docker-django-base.yaml
+++ b/.github/workflows/cdkactions_docker-django-base.yaml
@@ -56,7 +56,7 @@ jobs:
           push: ${{ github.ref == 'refs/heads/master' }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          build-args: PYTHON_VERSION=3.10.1
+          build-args: PYTHON_VERSION=3.10.18
           tags: pennlabs/django-base:${{ github.sha }}-3.10.18
   publish-django-base-3-11:
     name: Publish django-base-3-11

--- a/cdk/kraken/src/django.ts
+++ b/cdk/kraken/src/django.ts
@@ -15,7 +15,7 @@ export interface DjangoCheckJobProps {
 
   /**
    * Python version to test the project with.
-   * @default "3.8-buster"
+   * @default "3.10-bookworm"
    */
   pythonVersion?: string;
 
@@ -63,7 +63,7 @@ export class DjangoCheckJob extends CheckoutJob {
     // Build config
     const fullConfig: Required<DjangoCheckJobProps> = {
       id: "",
-      pythonVersion: "3.8-buster",
+      pythonVersion: "3.10-bookworm",
       path: ".",
       black: true,
       flake8: true,

--- a/cdk/kraken/test/__snapshots__/custom.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/custom.test.ts.snap
@@ -55,7 +55,7 @@ kubectl apply -f k8s/dist/ --prune -l app.kubernetes.io/part-of=$RELEASE_NAME",
     },
     "django-check-one": Object {
       "container": Object {
-        "image": "python:3.8-buster",
+        "image": "python:3.10-bookworm",
       },
       "env": Object {
         "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -124,7 +124,7 @@ pipenv run coverage xml",
     },
     "django-check-two": Object {
       "container": Object {
-        "image": "python:3.8-buster",
+        "image": "python:3.10-bookworm",
       },
       "env": Object {
         "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",

--- a/cdk/kraken/test/__snapshots__/django-project.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/django-project.test.ts.snap
@@ -5,7 +5,7 @@ Object {
   "jobs": Object {
     "django-check-custom": Object {
       "container": Object {
-        "image": "python:3.8-buster",
+        "image": "python:3.10-bookworm",
       },
       "env": Object {
         "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -126,7 +126,7 @@ Object {
   "jobs": Object {
     "django-check": Object {
       "container": Object {
-        "image": "python:3.8-buster",
+        "image": "python:3.10-bookworm",
       },
       "env": Object {
         "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",

--- a/cdk/kraken/test/__snapshots__/django.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/django.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`default 1`] = `
 Object {
   "container": Object {
-    "image": "python:3.8-buster",
+    "image": "python:3.10-bookworm",
   },
   "env": Object {
     "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -75,7 +75,7 @@ pipenv run coverage xml",
 exports[`different directory 1`] = `
 Object {
   "container": Object {
-    "image": "python:3.8-buster",
+    "image": "python:3.10-bookworm",
   },
   "env": Object {
     "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -219,7 +219,7 @@ pipenv run coverage xml",
 exports[`no lint 1`] = `
 Object {
   "container": Object {
-    "image": "python:3.8-buster",
+    "image": "python:3.10-bookworm",
   },
   "env": Object {
     "DATABASE_URL": "postgres://postgres:postgres@postgres:5432/postgres",
@@ -281,7 +281,7 @@ pipenv run coverage xml",
 exports[`with overrides 1`] = `
 Object {
   "container": Object {
-    "image": "python:3.8-buster",
+    "image": "python:3.10-bookworm",
   },
   "continue-on-error": true,
   "env": Object {

--- a/cdk/kraken/test/__snapshots__/labs-application.test.ts.snap
+++ b/cdk/kraken/test/__snapshots__/labs-application.test.ts.snap
@@ -45,7 +45,7 @@ jobs:
           name: codecov-umbrella
           verbose: true
     container:
-      image: python:3.8-buster
+      image: python:3.10-bookworm
     env:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
     services:
@@ -224,7 +224,7 @@ jobs:
           name: codecov-umbrella
           verbose: true
     container:
-      image: python:3.8-buster
+      image: python:3.10-bookworm
     env:
       DATABASE_URL: postgres://postgres:postgres@postgres:5432/postgres
     services:

--- a/docker/django-base/Dockerfile
+++ b/docker/django-base/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.10
+ARG PYTHON_VERSION=3.11
 FROM python:${PYTHON_VERSION}-slim-bookworm
 
 LABEL maintainer="Penn Labs"

--- a/docker/django-base/Dockerfile
+++ b/docker/django-base/Dockerfile
@@ -1,5 +1,5 @@
 ARG PYTHON_VERSION=3.10
-FROM python:${PYTHON_VERSION}-slim-buster
+FROM python:${PYTHON_VERSION}-slim-bookworm
 
 LABEL maintainer="Penn Labs"
 

--- a/docker/django-base/README.md
+++ b/docker/django-base/README.md
@@ -27,9 +27,9 @@ Because of this, each `django-base` is comprised of "Shared" and "Simple" tags. 
 
 For example, the current "Shared tag" can be `a142aa6975ee293bbc8a09ef0b81998ce7063dd3` and the current "Simple tag" is `a142aa6975ee293bbc8a09ef0b81998ce7063dd3-python3.10`.
 
-- `[sha]`: Python 3.10.1 (default)
-- `[sha]-3.10`: Python 3.10.1 (`penn-courses`)
-- `[sha]-3.9`: Python 3.9.14 (`penn-mobile`)
+- `[sha]`: Python 3.10 (default)
+- `[sha]-3.10`: Python 3.10.18 (`penn-courses`)
+- `[sha]-3.9`: Python 3.9.23 (`penn-mobile`)
 - `[sha]-3.8`: Python 3.8.11 (`penn-clubs`, `office-hours-queue`)
 
 ## Features
@@ -37,4 +37,4 @@ For example, the current "Shared tag" can be `a142aa6975ee293bbc8a09ef0b81998ce7
 This docker image contains pipenv and necessary packages to use `mysqlclient`
 
 ## Build Args
-The `django-base` image supports the build-arg `PYTHON_VERSION` which can be used to specify the python version to use. The default is `3.10.1`. 
+The `django-base` image supports the build-arg `PYTHON_VERSION` which can be used to specify the python version to use. The default is `3.10`. 

--- a/docker/django-base/README.md
+++ b/docker/django-base/README.md
@@ -27,10 +27,10 @@ Because of this, each `django-base` is comprised of "Shared" and "Simple" tags. 
 
 For example, the current "Shared tag" can be `a142aa6975ee293bbc8a09ef0b81998ce7063dd3` and the current "Simple tag" is `a142aa6975ee293bbc8a09ef0b81998ce7063dd3-python3.10`.
 
-- `[sha]`: Python 3.10 (default)
-- `[sha]-3.10`: Python 3.10.18 (`penn-courses`)
-- `[sha]-3.9`: Python 3.9.23 (`penn-mobile`)
-- `[sha]-3.8`: Python 3.8.11 (`penn-clubs`, `office-hours-queue`)
+- `[sha]`: Python 3.11 (default)
+- `[sha]-3.11`: Python 3.11 (`office-hours-queue`, `penn-mobile`, `penn-courses`)
+- `[sha]-3.10`: Python 3.10.18
+- `[sha]-3.9`: Python 3.9.23
 
 ## Features
 

--- a/docker/django-base/README.md
+++ b/docker/django-base/README.md
@@ -30,7 +30,6 @@ For example, the current "Shared tag" can be `a142aa6975ee293bbc8a09ef0b81998ce7
 - `[sha]`: Python 3.11 (default)
 - `[sha]-3.11`: Python 3.11 (`office-hours-queue`, `penn-mobile`, `penn-courses`)
 - `[sha]-3.10`: Python 3.10.18
-- `[sha]-3.9`: Python 3.9.23
 
 ## Features
 


### PR DESCRIPTION
Debian 10 (Buster) is end of life. This PR updates the Debian version in django-base to Debian 12 (Bookworm), and updates the Python versions that we support to include only Python 3.10.18 and Python 3.11. All existing products only use Python 3.11, so we can safely stop supporting the old versions.