### PR TITLE
Update hashes and bump to v1.0.4

### DIFF
--- a/docker/waypoint/install.sh
+++ b/docker/waypoint/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 INSTALL_DIR="/usr/local/bin"
-WAYPOINT_VERSION="v1.0.3"
+WAYPOINT_VERSION="v1.0.4"
 GITHUB_ORG="pennlabs"
 REPO_NAME="infrastructure"
 

--- a/docker/waypoint/setup.py
+++ b/docker/waypoint/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="waypoint",
-    version="1.0.3",
+    version="1.0.4",
     package_dir={"": "src"},
     py_modules=["main", "waypoint_client"],
     install_requires=[],

--- a/docker/waypoint/waypoint-init
+++ b/docker/waypoint/waypoint-init
@@ -7,7 +7,7 @@ PRODUCT_TO_SHA=(
   ["office-hours-queue"]="7fdcdaeba0b83600950edfbdfb155ba62cd2febd"
   ["penn-clubs"]="a69532b40c40c6ad0a2c6856e11034c70fbab26c"
   # ["penn-mobile"]="093a9f58ec7d778acc12dad40d0ece109e6346e8"
-  # ["penn-courses"]="e787256c332741db357baf3d005b20158d7b35c7"
+  ["penn-courses"]="b5cadf67f2924ed7ef77c59d81d3f08f9ebc05e0"
   # ["platform"]="022d2671a7811e8e2b6f772948ff28d18fa6422a"
 )
 

--- a/docker/waypoint/waypoint-init
+++ b/docker/waypoint/waypoint-init
@@ -2,10 +2,9 @@
 
 declare -A PRODUCT_TO_SHA
 
-# TODO: Add remaining products back since they aren't migrated to uv
 PRODUCT_TO_SHA=(
   ["office-hours-queue"]="7fdcdaeba0b83600950edfbdfb155ba62cd2febd"
-  ["penn-clubs"]="a69532b40c40c6ad0a2c6856e11034c70fbab26c"
+  ["penn-clubs"]="bf7176c476a4955a5872a69f85c377b8d6e0d66d"
   # ["penn-mobile"]="093a9f58ec7d778acc12dad40d0ece109e6346e8"
   ["penn-courses"]="b5cadf67f2924ed7ef77c59d81d3f08f9ebc05e0"
   # ["platform"]="022d2671a7811e8e2b6f772948ff28d18fa6422a"


### PR DESCRIPTION
Adds support for Penn Courses. We're still missing platform and mobile backend, since they haven't finished migrating to uv.